### PR TITLE
STCC-32: SwitchBackdropTo and SwitchBackdropToAndWait, Tests

### DIFF
--- a/src/scratchtocatrobat/converter/converter.py
+++ b/src/scratchtocatrobat/converter/converter.py
@@ -245,7 +245,8 @@ class _ScratchToCatrobat(object):
         # looks
         "lookLike:": catbricks.SetLookBrick,
         "nextCostume": catbricks.NextLookBrick,
-        "startScene": catbricks.BroadcastBrick,
+        "startScene": catbricks.SetBackgroundBrick,
+        "startSceneAndWait": catbricks.SetBackgroundAndWaitBrick,
         "nextScene": catbricks.NextLookBrick,  # only allowed in scene object so same as nextLook
 
         # video
@@ -1412,9 +1413,15 @@ class _BlocksConversionTraverser(scratch.AbstractBlocksTraverser):
     @_register_handler(_block_name_to_handler_map, "startScene")
     def _convert_scene_block(self):
         [look_name] = self.arguments
-        # TODO: implement!
-        #if look_name == "next backdrop": => use NextLookBrick
-        #if look_name == "previous backdrop": => not sure...
+
+        #TODO: If SetBackgroundBrick gets Formula as accepted argument for Constructor,
+        #      then extend this register_handler accordingly.
+
+        if look_name == "next backdrop":
+            return catbricks.NextLookBrick()
+        if look_name == "previous backdrop":
+            return catbricks.PreviousLookBrick()
+
         background_sprite = catrobat.background_sprite_of(self.scene)
         if not background_sprite:
             assert catrobat.is_background_sprite(self.sprite)
@@ -1423,15 +1430,37 @@ class _BlocksConversionTraverser(scratch.AbstractBlocksTraverser):
         if not matching_looks:
             raise ConversionError("Background does not contain look with name: {}".format(look_name))
         assert len(matching_looks) == 1
-        [matching_look] = matching_looks
-        look_message = _background_look_to_broadcast_message(look_name)
-        broadcast_brick = self.CatrobatClass(look_message)
-        broadcast_script = catbase.BroadcastScript(look_message)
-        set_look_brick = catbricks.SetLookBrick()
-        set_look_brick.setLook(matching_look)
-        broadcast_script.addBrick(set_look_brick)
-        background_sprite.addScript(broadcast_script)
-        return [broadcast_brick]
+
+        switch_background_brick = self.CatrobatClass()
+        switch_background_brick.setLook(matching_looks[0])
+
+        return switch_background_brick
+
+    @_register_handler(_block_name_to_handler_map, "startSceneAndWait")
+    def _convert_scene_and_wait_block(self):
+        [look_name] = self.arguments
+
+        #TODO: If SetBackgroundBrick gets Formula as accepted argument for Constructor,
+        #      then extend this register_handler accordingly.
+
+        if look_name == "next backdrop":
+            return catbricks.NextLookBrick()
+        if look_name == "previous backdrop":
+            return catbricks.PreviousLookBrick()
+
+        background_sprite = catrobat.background_sprite_of(self.scene)
+        if not background_sprite:
+            assert catrobat.is_background_sprite(self.sprite)
+            background_sprite = self.sprite
+        matching_looks = [_ for _ in background_sprite.getLookDataList() if _.getLookName() == look_name]
+        if not matching_looks:
+            raise ConversionError("Background does not contain look with name: {}".format(look_name))
+        assert len(matching_looks) == 1
+
+        switch_background_brick = self.CatrobatClass()
+        switch_background_brick.setLook(matching_looks[0])
+
+        return switch_background_brick
 
     @_register_handler(_block_name_to_handler_map, "doIf")
     def _convert_if_block(self):

--- a/src/scratchtocatrobat/converter/test_converter.py
+++ b/src/scratchtocatrobat/converter/test_converter.py
@@ -323,7 +323,7 @@ class TestConvertBlocks(common_testing.BaseTestCase):
         self.test_project.getDefaultScene().spriteList.add(self.sprite_stub)
         catr_script = self.block_converter._catrobat_script_from(scratch_script, DUMMY_CATR_SPRITE, self.test_project)
         assert isinstance(catr_script, catbase.WhenBackgroundChangesScript)
-        assert catr_script.getLook().name == "look1"
+        assert catr_script.getLook().getLookName() == "look1"
         assert catr_script.getLook() == self.sprite_stub.getLookDataList()[0]
         assert len(catr_script.getBrickList()) == 1
         assert isinstance(catr_script.getBrickList()[0], catbricks.SayBubbleBrick)
@@ -353,7 +353,7 @@ class TestConvertBlocks(common_testing.BaseTestCase):
         self.test_project.getDefaultScene().spriteList.add(self.sprite_stub)
         catr_script = self.block_converter._catrobat_script_from(raw_project.objects[0].scripts[0], DUMMY_CATR_SPRITE, self.test_project)
         assert isinstance(catr_script, catbase.WhenBackgroundChangesScript)
-        assert catr_script.getLook().name == "look1"
+        assert catr_script.getLook().getLookName() == "look1"
         assert catr_script.getLook() == self.sprite_stub.getLookDataList()[0]
         assert len(catr_script.getBrickList()) == 0
 
@@ -1604,23 +1604,47 @@ class TestConvertBlocks(common_testing.BaseTestCase):
 
     # startScene
     def test_can_convert_startscene_block(self):
-        scratch_block = _, look_name = ["startScene", "look1"]
-        script = scratch.Script([30, 355, [['whenGreenFlag'], scratch_block]])
-        project = catbase.Project(None, "TestDummyProject")
-        scene = catbase.Scene(None, "Scene 1", project)
-        scene.addSprite(self.sprite_stub)
-        project.sceneList.add(scene)
-        converter._catr_project = project
-        catr_script = self.block_converter._catrobat_script_from(script, self.sprite_stub, self.test_project)
-        converter._catr_project = None
-        stub_scripts = self.sprite_stub.scriptList
-        assert stub_scripts.size() == 1
-        assert isinstance(stub_scripts.get(0), catbase.BroadcastScript)
+        scratch_script= scratch.Script([321, 89, [["whenSceneStarts", "look1"], ["startScene", "look2"]]])
+        self.test_project.getDefaultScene().spriteList.add(self.sprite_stub)
+        catr_script = self.block_converter._catrobat_script_from(scratch_script, DUMMY_CATR_SPRITE, self.test_project)
+        assert isinstance(catr_script.getBrickList()[0], catbricks.SetBackgroundBrick)
+        assert catr_script.getBrickList()[0].getLook().getLookName() == "look2"
+        assert catr_script.getBrickList()[0].getLook() == self.sprite_stub.getLookDataList()[1]
+        assert len(catr_script.getBrickList()) == 1
 
-        expected_msg = converter._background_look_to_broadcast_message(look_name)
-        assert expected_msg, stub_scripts.get(0).getBroadcastMessage()
-        assert isinstance(catr_script.getBrickList().get(0), catbricks.BroadcastBrick)
-        assert expected_msg, catr_script.getBrickList().get(0).getBroadcastMessage()
+    # startScene
+    def test_can_convert_startscene_next_backdrop_block(self):
+        scratch_block = ["startScene", "next backdrop"]
+        [catr_brick] = self.block_converter._catrobat_bricks_from(scratch_block, DUMMY_CATR_SPRITE)
+        assert isinstance(catr_brick, catbricks.NextLookBrick)
+
+    # startScene
+    def test_can_convert_startscene_previous_backdrop_block(self):
+        scratch_block = ["startScene", "previous backdrop"]
+        [catr_brick] = self.block_converter._catrobat_bricks_from(scratch_block, DUMMY_CATR_SPRITE)
+        assert isinstance(catr_brick, catbricks.PreviousLookBrick)
+
+    # startSceneAndWait
+    def test_can_convert_startscene_wait_block(self):
+        scratch_script= scratch.Script([321, 89, [["whenSceneStarts", "look1"], ["startSceneAndWait", "look2"]]])
+        self.test_project.getDefaultScene().spriteList.add(self.sprite_stub)
+        catr_script = self.block_converter._catrobat_script_from(scratch_script, DUMMY_CATR_SPRITE, self.test_project)
+        assert isinstance(catr_script.getBrickList()[0], catbricks.SetBackgroundBrick)
+        assert catr_script.getBrickList()[0].getLook().getLookName() == "look2"
+        assert catr_script.getBrickList()[0].getLook() == self.sprite_stub.getLookDataList()[1]
+        assert len(catr_script.getBrickList()) == 1
+
+    # startSceneAndWait
+    def test_can_convert_startscene_wait_next_backdrop_block(self):
+        scratch_block = ["startSceneAndWait", "next backdrop"]
+        [catr_brick] = self.block_converter._catrobat_bricks_from(scratch_block, DUMMY_CATR_SPRITE)
+        assert isinstance(catr_brick, catbricks.NextLookBrick)
+
+    # startSceneAndWait
+    def test_can_convert_startscene_wait_previous_backdrop_block(self):
+        scratch_block = ["startSceneAndWait", "previous backdrop"]
+        [catr_brick] = self.block_converter._catrobat_bricks_from(scratch_block, DUMMY_CATR_SPRITE)
+        assert isinstance(catr_brick, catbricks.PreviousLookBrick)
 
     # sayBubbleBrick
     def test_can_convert_say_bubble_brick(self):


### PR DESCRIPTION
**Remarks:**

If SetBackgroundBrick gets Formula as accepted argument for Constructor, then extend this startScene and startSceneAndWait register_handler accordingly. We momentarily can't get a look from the 
looklist based on a formula, because we are not able to evaluate every formula, since some values (i.e. from UserVariables) are only known at runtime.