### PR TITLE
[STCC-190] - fix crash when block is in incorrect format

### DIFF
--- a/src/scratchtocatrobat/scratch/scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3.py
@@ -84,7 +84,10 @@ class Scratch3Parser(object):
         script_blocks = []
         temp_block_dict = {}
         for block in sprite["blocks"]:
-            temp_block_dict[block] = Scratch3Block(sprite["blocks"][block], block)
+            try:
+                temp_block_dict[block] = Scratch3Block(sprite["blocks"][block], block)
+            except AttributeError as ex:
+                log.warn("Block with id: " + block + " could not be parsed: " + ex.message)
 
         for blockId in temp_block_dict:
             self.build_block_structure(blockId, temp_block_dict)


### PR DESCRIPTION
This exception gets thrown when a block that is not a part of any script is included in the project.json.