### PR TITLE
Fix exceptions in media converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ sudo apt-get install python
 ```sh
 sudo apt-get install sox
 ```
+* Install npm via aptitude (if not already installed):
+```sh
+sudo apt-get install nodejs
+```
+* Install svg2png via npm (needed for svg conversion):
+```sh
+npm install svg2png -g
+```
 * Jython 2.7 requires java version 1.8 or later. To determine the currently installed java version run the following command on your shell:
 ```sh
 java -version

--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  984
+build_number:  985
 
 ;-------------------------------------------------------------------------------
 [CATROBAT]


### PR DESCRIPTION
Uses the npm package svg2png to do the conversion from svg to png, as batik can't handle some of the attributes in svg files that were introduced with Scratch3
Install with: npm install svg2png -g