### PR TITLE
STCC-119_resource-file-name-wrong-in-mediaconverter

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  989
+build_number:  991
 
 ;-------------------------------------------------------------------------------
 [CATROBAT]


### PR DESCRIPTION
The project in question converts without problems. The code causing the problem has already been refactored and does not exist anymore.