### PR TITLE
STCC-201 remove branchname in versionnumber

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  980
+build_number:  986-STCC-201_version_number_without_branchname
 
 ;-------------------------------------------------------------------------------
 [CATROBAT]

--- a/src/scratchtocatrobat/tools/helpers.py
+++ b/src/scratchtocatrobat/tools/helpers.py
@@ -291,9 +291,7 @@ def inject_git_commmit_hook():
         CONFIG_CUSTOM_ENV_FILE_PATH="%s"
         branchName=`/usr/bin/env git symbolic-ref HEAD | sed -e 's,.*/\\(.*\\),\\1,'`
         gitCount=`/usr/bin/env git rev-list $branchName |wc -l | sed 's/^ *//;s/ *$//'`
-        simpleBranchName=`/usr/bin/env git rev-parse --abbrev-ref HEAD`
         buildNumber="$((gitCount + 1))"
-        buildNumber+="-$simpleBranchName"
 
         /usr/bin/env python - <<EOF
             def update_build_number(config_file_name, number):


### PR DESCRIPTION
Removed the branchname from the versionnumber in the
pre-commit hook