### PR TITLE
STCC-202 reimplemented metadata http retries

### DIFF
--- a/src/scratchtocatrobat/scratch/scratchwebapi.py
+++ b/src/scratchtocatrobat/scratch/scratchwebapi.py
@@ -155,38 +155,39 @@ def downloadProjectMetaData(project_id, retry_after_http_status_exception=False)
     import urllib2
 
     scratch_project_url = SCRATCH_PROJECT_META_DATA_BASE_URL + str(project_id)
+    retries = HTTP_RETRIES if retry_after_http_status_exception else 0
 
+    def retry_hook(exc, tries, delay):
+        _log.warn("  Exception: {}\nRetrying {} after {}:'{}' in {} secs (remaining" \
+                "tries: {})".format(sys.exc_info()[0], scratch_project_url, type(ex).__name__, exc, \
+                delay, tries))
 
-    try:
-        response = urllib2.urlopen(scratch_project_url,timeout=HTTP_TIMEOUT)
-        html = response.read()
-        document = json.loads(html)
-        if document != None:
-            document["meta_data_timestamp"] = datetime.now()
-            _cached_jsoup_documents[project_id] = document
-            _projectMetaData[project_id] = document
-        return document
-    except urllib2.HTTPError as e:
-        if e.code == 404:
-            _log.error("HTTP 404 - Not found! Project not available.")
-            return None
-        else:
+    @helpers.retry((urllib2.URLError,), tries=retries, delay=HTTP_DELAY, \
+            backoff=HTTP_BACKOFF, hook=retry_hook)
+    def download_request(scratch_url, timeout):
+        try:
+            response = urllib2.urlopen(scratch_url, timeout=timeout)
+            html = response.read()
+            document = json.loads(html)
+            if document != None:
+                document["meta_data_timestamp"] = datetime.now()
+                _cached_jsoup_documents[project_id] = document
+                _projectMetaData[project_id] = document
+            return document
+        except urllib2.HTTPError as e:
+            if e.code == 404:
+                _log.error(str(e) + " Project not available.")
+                return None
             raise e
+    try:
+        return download_request(scratch_project_url, HTTP_TIMEOUT)
     except:
         _log.error("Retry limit exceeded or an unexpected error occurred: {}".format(sys.exc_info()[0]))
         return None
 
 # TODO: class instead of request functions
 def request_is_project_available(project_id):
-    from org.jsoup import HttpStatusException
-    try:
-        return downloadProjectMetaData(project_id, False) is not None
-    except HttpStatusException as e:
-        if e.getStatusCode() == 404:
-            _log.error("HTTP 404 - Not found! Project not available.")
-            return False
-        else:
-            raise e
+    return downloadProjectMetaData(project_id, False) is not None
 
 
 def request_project_remixes_for(project_id):

--- a/web/worker/converterjob.py
+++ b/web/worker/converterjob.py
@@ -206,34 +206,11 @@ def convert_scratch_project(job_ID, host, port, verbose):
         _logger.error("Cannot find server certificate: %s", CERTIFICATE_PATH)
         return
 
-    # retries = int(helpers.config.get("SCRATCH_API", "http_retries"))
-    # timeout_in_secs = int(helpers.config.get("SCRATCH_API", "http_timeout")) / 1000
-    # backoff = int(helpers.config.get("SCRATCH_API", "http_backoff"))
-    # delay = int(helpers.config.get("SCRATCH_API", "http_delay"))
-    # user_agent = helpers.config.get("SCRATCH_API", "user_agent")
-    #
-    # # preprocessing: fetch project title and project image URL via web API
-    # def retry_hook(exc, tries, delay):
-    #     _logger.warning("  Exception: {}\nRetrying after {}:'{}' in {} secs (remaining trys: {})" \
-    #                     .format(sys.exc_info()[0], type(exc).__name__, exc, delay, tries))
-    #
-    # @helpers.retry((urllib2.URLError, socket.timeout, IOError, BadStatusLine), delay=delay,
-    #                backoff=backoff, tries=retries, hook=retry_hook)
-    # def read_content_of_url(url):
-    #     _logger.info("Fetching project title from: {}".format(scratch_project_url))
-    #     req = urllib2.Request(url, headers={ "User-Agent": user_agent })
-    #     return urllib2.urlopen(req, timeout=timeout_in_secs).read()
-
     title = None
     image_URL = None
     scratch_project_url = "%s%d" % (SCRATCH_PROJECT_META_DATA_BASE_URL, job_ID)
     try:
-        # html_content = read_content_of_url(scratch_project_url)
-
-        # document = webhelpers.ResponseBeautifulSoupDocumentWrapper(BeautifulSoup(html_content.decode('utf-8', 'ignore'), b'html5lib'))
-        # document = document.wrapped_document.text()
         title, image_URL = scratchwebapi.getMetaDataEntry(job_ID, "title", "image")
-        # image_URL = scratchwebapi.getMetaDataEntry(job_ID, "image")
         if title == None:
             raise Warning("Unable to set title of project from the project's website!" \
                           " Reason: Cannot parse title from returned html content!")


### PR DESCRIPTION
scratchwebapi.downloadProjectMetaData retries to build the connection
if the retry parameter is true.

It only retries if no connection to the server can be made,
or an unecpected statuscode is returned, but not when the server
answers with a 404 (then it logs it and returns None).

Removed old jsoup try/except in call of downloadProjectMetaData