### PR TITLE
STCC-212/STCC-213 Exception when accessing user lists

### DIFF
--- a/src/scratchtocatrobat/converter/converter.py
+++ b/src/scratchtocatrobat/converter/converter.py
@@ -1050,7 +1050,8 @@ class _ScratchObjectConverter(object):
         if not scratch_object.is_stage() and scratch_object.get_lists() is not None:
             for user_list_data in scratch_object.get_lists():
                 assert len(user_list_data["listName"]) > 0
-                sprite.userLists.add(user_list_data["listName"])
+                user_list = catformula.UserList(user_list_data["listName"])
+                sprite.userLists.add(user_list)
                 # TODO: check if user list has been added...
 
         for scratch_variable in scratch_object.get_variables():


### PR DESCRIPTION
UserList object was not created, but a string was added to the Sprite's userLists ArrayList instead. Fixed the bug. NOTE: This issue requires STCC-210 to be merged into the develop before in order to list user list names properly since the new lib that is introduced in that issue also affects user lists.