### PR TITLE
STCC-218 fixed svg to png conversion error when height and width attribute were missing

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  998
+build_number:  1005
 build_type: S2CC
 
 ;-------------------------------------------------------------------------------

--- a/src/scratchtocatrobat/tools/svgtopng.py
+++ b/src/scratchtocatrobat/tools/svgtopng.py
@@ -210,6 +210,14 @@ def _parse_and_rewrite_svg_file(svg_input_path, svg_output_path):
     if 'width' in root.attrib and float((root.attrib['width']).strip('px%')) <= 0:
         root.attrib['width'] = '1'
 
+    #some SVGs do not contain height and width attributes - viewbox attribute can be used to determine those parameters
+    if not 'height' in root.attrib and not 'width' in root.attrib:
+        if 'viewBox' in root.attrib:
+            viewBox_values = _get_viewbox_values(root.attrib['viewBox'])
+            height = (max(viewBox_values[1], viewBox_values[3]) - min(viewBox_values[1], viewBox_values[3]))
+            width = (max(viewBox_values[0], viewBox_values[2]) - min(viewBox_values[0], viewBox_values[2]))
+            root.set('height', str(height))
+            root.set('width', str(width))
 
     # uncrop image if and only if everything is in a g tag
     for child in root:


### PR DESCRIPTION
The error was caused because the SVG root did not contain the height and width attributes, which were needed later during conversion. By determining height and width from the viewBox attribute and adding the missing attributes manually the conversion can finish successfully.