### PR TITLE
STCC-219 fixed svg-to-png conversion error with xml register_namespace

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1002
+build_number:  1007
 build_type: S2CC
 
 ;-------------------------------------------------------------------------------

--- a/src/scratchtocatrobat/converter/mediaconverter.py
+++ b/src/scratchtocatrobat/converter/mediaconverter.py
@@ -22,6 +22,7 @@
 import os
 import shutil
 from threading import Thread
+from threading import Lock
 from java.awt import Color
 
 from scratchtocatrobat.tools import logger
@@ -37,6 +38,7 @@ from javax.imageio import ImageIO
 
 MAX_CONCURRENT_THREADS = int(helpers.config.get("MEDIA_CONVERTER", "max_concurrent_threads"))
 log = logger.log
+ns_registry_lock = Lock()
 
 
 class MediaType(object):
@@ -73,7 +75,7 @@ class _MediaResourceConverterThread(Thread):
 
         if media_type == MediaType.UNCONVERTED_SVG:
             # converting svg to png -> new md5 and filename
-            new_src_path = svgtopng.convert(old_src_path, info["rotationCenterX"], info["rotationCenterY"])
+            new_src_path = svgtopng.convert(old_src_path, info["rotationCenterX"], info["rotationCenterY"], ns_registry_lock)
         elif media_type == MediaType.UNCONVERTED_WAV:
             # converting Android-incompatible wav to compatible wav
             new_src_path = wavconverter.convert_to_android_compatible_wav(old_src_path)

--- a/src/scratchtocatrobat/converter/test_converter.py
+++ b/src/scratchtocatrobat/converter/test_converter.py
@@ -21,6 +21,7 @@
 import os
 import unittest
 import re
+from threading import Lock
 
 import org.catrobat.catroid.common as catcommon
 import org.catrobat.catroid.content as catbase
@@ -40,6 +41,7 @@ from scratchtocatrobat.converter import converter
 
 BACKGROUND_LOCALIZED_GERMAN_NAME = "Hintergrund"
 BACKGROUND_ORIGINAL_NAME = "Stage"
+ns_registry_lock = Lock()
 
 
 def create_catrobat_sprite_stub(name=None):
@@ -2643,7 +2645,7 @@ class TestConvertProjects(common_testing.ProjectTestCase):
             if re.search('.*}g', child.tag) != None:
                 if 'transform' in child.attrib:
                     assert(child.attrib['transform'] == "matrix(1.5902323722839355, 0, 0, 1.5902323722839355, -0.5, 0.5)")
-        svgtopng._parse_and_rewrite_svg_file("test/res/scratch/Wizard_Spells/3.svg","test/res/scratch/Wizard_Spells/3_changed.svg")
+        svgtopng._parse_and_rewrite_svg_file("test/res/scratch/Wizard_Spells/3.svg","test/res/scratch/Wizard_Spells/3_changed.svg", ns_registry_lock)
         tree = ET.parse("test/res/scratch/Wizard_Spells/3_changed.svg")
         root = tree.getroot()
         for child in root:
@@ -2658,7 +2660,7 @@ class TestConvertProjects(common_testing.ProjectTestCase):
             if re.search('.*}text', child.tag) != None:
                 assert(child.attrib['x'] == '147.5')
                 assert(child.attrib['y'] == '146.1')
-        svgtopng._parse_and_rewrite_svg_file("test/res/scratch/Wizard_Spells/6.svg","test/res/scratch/Wizard_Spells/6_changed.svg")
+        svgtopng._parse_and_rewrite_svg_file("test/res/scratch/Wizard_Spells/6.svg","test/res/scratch/Wizard_Spells/6_changed.svg", ns_registry_lock)
         tree = ET.parse("test/res/scratch/Wizard_Spells/6_changed.svg")
         root = tree.getroot()
         for child in root:

--- a/src/scratchtocatrobat/tools/test_svgtopng.py
+++ b/src/scratchtocatrobat/tools/test_svgtopng.py
@@ -22,10 +22,13 @@ import imghdr
 import os
 import shutil
 import unittest
+from threading import Lock
 
 from scratchtocatrobat.tools import common_testing
 from scratchtocatrobat.tools import svgtopng
 from scratchtocatrobat.tools import helpers
+
+ns_registry_lock = Lock()
 
 class SvgToPngTest(common_testing.BaseTestCase):
 
@@ -49,7 +52,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
         
         rotation_x, rotation_y = 36, 67
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
         
         from javax.imageio import ImageIO
         from java.io import File
@@ -76,7 +79,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
         
         rotation_x, rotation_y = 255, 180
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
         
         from javax.imageio import ImageIO
         from java.io import File
@@ -103,7 +106,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
         
         rotation_x, rotation_y = 53, 43
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
         
         from javax.imageio import ImageIO
         from java.io import File
@@ -133,7 +136,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
                                            str(rotation_x) + "_rotY_" + str(rotation_y) + 
                                            ".png")
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
 
         from javax.imageio import ImageIO
         from java.io import File
@@ -163,7 +166,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
                                            str(rotation_x) + "_rotY_" + str(rotation_y) + 
                                            ".png")
                 
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
 
         from javax.imageio import ImageIO
         from java.io import File
@@ -193,7 +196,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
                                            str(rotation_x) + "_rotY_" + str(rotation_y) + 
                                            ".png")
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
 
         from javax.imageio import ImageIO
         from java.io import File
@@ -223,7 +226,7 @@ class SvgToPngTest(common_testing.BaseTestCase):
                                            str(rotation_x) + "_rotY_" + str(rotation_y) + 
                                            ".png")
         
-        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y)
+        output_png_path = svgtopng.convert(input_svg_path, rotation_x, rotation_y, ns_registry_lock)
 
         from javax.imageio import ImageIO
         from java.io import File


### PR DESCRIPTION
This error occured when multiple svg conversions where running at the same time and were modifying the global dictionary matching namespace uri and their prefixes. Locking the call to register_namespace seems to have fixed the problem. 

Testing is difficult as this error appeared randomly and cannot be reproduced on command. It appeared most often when converting projects with a large number of images. 
How I did test: converting about 200 projects where I knew those errors occured multiple times in the past (from testing and using run_statistics) and this error did not appear again. 