### PR TITLE
[STCC-155-224] rename media files

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1002
+build_number:  1008
 build_type: S2CC
 
 ;-------------------------------------------------------------------------------

--- a/src/scratchtocatrobat/converter/mediaconverter.py
+++ b/src/scratchtocatrobat/converter/mediaconverter.py
@@ -46,24 +46,6 @@ class MediaType(object):
     UNCONVERTED_WAV = 4
 
 
-def catrobat_resource_file_name_for(scratch_md5_name, scratch_resource_name):
-    assert os.path.basename(scratch_md5_name) == scratch_md5_name \
-    and len(os.path.splitext(scratch_md5_name)[0]) == 32, \
-    "Must be MD5 hash with file ext: " + scratch_md5_name
-
-    # remove unsupported unicode characters from filename
-#     if isinstance(scratch_resource_name, unicode):
-#         scratch_resource_name = unicodedata.normalize('NFKD', scratch_resource_name).encode('ascii','ignore')
-#         if (scratch_resource_name == None) or (len(scratch_resource_name) == 0):
-#             scratch_resource_name = "unicode_replaced"
-    resource_ext = os.path.splitext(scratch_md5_name)[1]
-    return scratch_md5_name.replace(resource_ext, "_" + scratch_resource_name.replace("/",'') + resource_ext)
-
-
-def _resource_name_for(file_path):
-    return common.md5_hash(file_path) + os.path.splitext(file_path)[1]
-
-
 class _MediaResourceConverterThread(Thread):
 
     def run(self):
@@ -95,7 +77,7 @@ class MediaConverter(object):
         self.catrobat_program = catrobat_program
         self.images_path = images_path
         self.sounds_path = sounds_path
-        self.renamed_files_map = {}
+        self.file_rename_map = {}
 
 
     def convert(self, progress_bar = None):
@@ -213,8 +195,10 @@ class MediaConverter(object):
         assert reference_index == resource_index and reference_index == num_total_resources
 
         converted_media_files_to_be_removed = set()
+        duplicate_filename_set = set()
         for resource_info in all_used_resources:
-            scratch_md5_name = resource_info["scratch_md5_name"]
+            # reconstruct the temporary catrobat filenames -> catrobat.media_objects_in(self.catrobat_file)
+            current_filename = helpers.create_catrobat_md5_filename(resource_info["scratch_md5_name"], duplicate_filename_set)
 
             # check if path changed after conversion
             old_src_path = resource_info["src_path"]
@@ -256,39 +240,51 @@ class MediaConverter(object):
                     # TODO: move test_converter.py to converter-python-package...
                     image_processing.save_editable_image_as_png_to_disk(editable_image, image_file_path, overwrite=True)
 
-            self._copy_media_file(scratch_md5_name, src_path, resource_info["dest_path"],
-                                  resource_info["media_type"])
+            current_basename, _ = os.path.splitext(current_filename)
+            self.file_rename_map[current_basename] = {}
+            self.file_rename_map[current_basename]["src_path"] = src_path
+            self.file_rename_map[current_basename]["dst_path"] = resource_info["dest_path"]
+            self.file_rename_map[current_basename]["media_type"] = resource_info["media_type"]
 
             if resource_info["media_type"] in { MediaType.UNCONVERTED_SVG, MediaType.UNCONVERTED_WAV }:
                 converted_media_files_to_be_removed.add(src_path)
 
-        self._update_file_names_of_converted_media_files()
+        self.rename_media_files_and_copy()
 
+        # delete converted png files -> only temporary saved
         for media_file_to_be_removed in converted_media_files_to_be_removed:
             os.remove(media_file_to_be_removed)
 
+    # rename the media files and copy them to the catrobat project directory
+    def rename_media_files_and_copy(self):
 
-    def _update_file_names_of_converted_media_files(self):
-        for (old_file_name, new_file_name) in self.renamed_files_map.iteritems():
-            look_data_or_sound_infos = filter(lambda info: info.fileName == old_file_name,
-                                      catrobat.media_objects_in(self.catrobat_program))
-            # assert len(look_data_or_sound_infos) > 0
+        def create_new_file_name(provided_file, index_helper, file_type):
+            _, ext = os.path.splitext(provided_file)
+            if file_type in {MediaType.UNCONVERTED_SVG, MediaType.IMAGE}:
+                return "img_#" + str(index_helper.assign_image_index()) + ext
+            else:
+                return "snd_#" + str(index_helper.assign_sound_index()) + ext
 
-            for info in look_data_or_sound_infos:
-                info.fileName = new_file_name
+        media_file_index_helper = helpers.MediaFileIndex()
+        for info in catrobat.media_objects_in(self.catrobat_program):
+            basename, _ = os.path.splitext(info.fileName)
+
+            # ignore these files, already correctly provided by the converter
+            if any(x in basename for x in ["key", "mouse"]):
+                continue
+
+            assert basename in self.file_rename_map and \
+                "src_path" in self.file_rename_map[basename] and \
+                "dst_path" in self.file_rename_map[basename] and \
+                "media_type" in self.file_rename_map[basename]
 
 
-    def _copy_media_file(self, scratch_md5_name, src_path, dest_path, media_type):
-        # for Catrobat separate file is needed for resources which are used multiple times but with different names
-        for scratch_resource_name in self.scratch_project.find_all_resource_names_for(scratch_md5_name):
-            new_file_name = catrobat_resource_file_name_for(scratch_md5_name, scratch_resource_name)
-            if media_type in { MediaType.UNCONVERTED_SVG, MediaType.UNCONVERTED_WAV }:
-                old_file_name = new_file_name
-                converted_scratch_md5_name = _resource_name_for(src_path)
-                new_file_name = catrobat_resource_file_name_for(converted_scratch_md5_name,
-                                                                scratch_resource_name)
-                self.renamed_files_map[old_file_name] = new_file_name
-            shutil.copyfile(src_path, os.path.join(dest_path, new_file_name))
+            src_path = self.file_rename_map[basename]["src_path"]
+            dst_path = self.file_rename_map[basename]["dst_path"]
+            media_type = self.file_rename_map[basename]["media_type"]
+            new_file_name = create_new_file_name(src_path, media_file_index_helper, media_type)
+            shutil.copyfile(src_path, os.path.join(dst_path, new_file_name))
+            info.fileName = new_file_name
 
     def resize_png(self, path_in, path_out, bitmapResolution):
         import java.awt.image.BufferedImage

--- a/src/scratchtocatrobat/converter/test_converter.py
+++ b/src/scratchtocatrobat/converter/test_converter.py
@@ -2486,7 +2486,7 @@ class TestConvertedProjectAppendedKeySpriteScripts(common_testing.ProjectTestCas
 
         key_w = default_scene.spriteList[2]
         assert key_w != None
-        assert key_w.name == 'key w pressed'
+        assert key_w.name == 'key_w_pressed'
 
         scripts = key_w.getScriptList()
         assert len(scripts) == 3
@@ -2548,7 +2548,7 @@ class TestConvertedProjectAppendedKeySpriteScripts(common_testing.ProjectTestCas
 
         broadcast_script = spritescripts[1]
         assert isinstance(broadcast_script, catbase.BroadcastScript)
-        assert broadcast_script.getBroadcastMessage() == 'key space pressed'
+        assert broadcast_script.getBroadcastMessage() == 'key_space_pressed'
 
         sprite_brick_list = spritescripts[1].getBrickList()
         assert len(sprite_brick_list) == 1
@@ -2558,7 +2558,7 @@ class TestConvertedProjectAppendedKeySpriteScripts(common_testing.ProjectTestCas
 
         key_space = default_scene.spriteList[2]
         assert key_space != None
-        assert key_space.name == 'key space pressed'
+        assert key_space.name == 'key_space_pressed'
 
         keyscripts = key_space.getScriptList()
         assert len(keyscripts) == 2
@@ -2569,7 +2569,7 @@ class TestConvertedProjectAppendedKeySpriteScripts(common_testing.ProjectTestCas
 
         broadcast_brick = key_brick_list[0]
         assert isinstance(broadcast_brick, catbricks.BroadcastBrick)
-        assert broadcast_brick.getBroadcastMessage() == 'key space pressed'
+        assert broadcast_brick.getBroadcastMessage() == 'key_space_pressed'
 
 
 

--- a/src/scratchtocatrobat/tools/helpers.py
+++ b/src/scratchtocatrobat/tools/helpers.py
@@ -464,3 +464,39 @@ class ProgressBar(object):
             self._output_stream.write("{}{}{}\n".format(ProgressBar.START_PROGRESS_INDICATOR, \
                                                       round(percentage, 2), \
                                                       ProgressBar.END_PROGRESS_INDICATOR))
+
+
+# create a unique name for a catrobat media file -> name derived from scratch md5-hash
+# since one file might be used for multiple objects, the md5-hash is extended with a unique identifier
+# name used until all files, converted or unconverted, are copied to the catrobat project directory
+def create_catrobat_md5_filename(scratch_md5_name, duplicate_file_set):
+    filename, ext = os.path.splitext(scratch_md5_name)
+    current_filename = filename + "_#0" + ext
+    next_index = 1
+    while current_filename in duplicate_file_set:
+        current_filename = filename + "_#" + str(next_index) + ext
+        next_index += 1
+    duplicate_file_set.add(current_filename)
+    return current_filename
+
+
+class MediaFileIndex:
+    def __init__(self):
+        self.img_idx = 0
+        self.snd_idx = 0
+
+    def increment_image_index(self):
+        self.img_idx += 1
+
+    def increment_sound_index(self):
+        self.snd_idx += 1
+
+    def assign_image_index(self):
+        current_image_index = self.img_idx
+        self.increment_image_index()
+        return current_image_index
+
+    def assign_sound_index(self):
+        current_sound_index = self.snd_idx
+        self.increment_sound_index()
+        return current_sound_index


### PR DESCRIPTION
Initially all costumes and sounds were named using the following information from the scratch project file: 
- md5-hash of the file = 32 character long id
- costume name or sound name

Since the same images result in the same md5-hash and different objects can have a costume with the same name, it was possible that some files had the same name, which resulted in overwriting of existing files -> not all costumes and sounds had their own resource file. This was a problem for catrobat, because deleting e.g. a costume of an object could also have an impact on other objects (costume deleted as well).

The new proposed solution is to name the files as following:
- use md5-hash of the resource file and extended with an id ("_#0")
- if a md5-hash was already used, extend it with an increased id

These names are used until conversion of all unconverted files is finished, then the names of the catrobat files are replaced with something like "img_#0.png" and "snd_#0.wav" to keep it short and simple.

---

It was also considered to name the files after object and costume/sound name, which resulted in the following problems:

- illegal characters in object name or image/sound name could cause problems for various operating systems -> replacing them with different characters could result in a filename collision (initial problem)
- scratch allows very long names for objects and costumes/sounds -> using them for filenames results in conversion failure (filename too long); slicing the names could again result in filename collisions

One last possible solution to name the files after object + costume/sound would be to cut the names to a certain length and add an id at the end, if collisions occur -> debatable how useful this naming convention is.
