### PR TITLE
[STCC-229] variables not referenced correctly

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1008
+build_number:  1011
 build_type: S2CC
 
 ;-------------------------------------------------------------------------------

--- a/src/scratchtocatrobat/converter/converter.py
+++ b/src/scratchtocatrobat/converter/converter.py
@@ -2151,14 +2151,12 @@ class _BlocksConversionTraverser(scratch.AbstractBlocksTraverser):
     @_register_handler(_block_name_to_handler_map, "changeVar:by:", "setVar:to:")
     def _convert_variable_block(self):
         [variable_name, value] = self.arguments
+                
+        # try to access a local variable with the given name
+        # if no local variable is found, a global variable is referenced
         user_variable = self.sprite.getUserVariable(variable_name)
         if user_variable is None:
-            # WORKAROUND: for generated variables added in preprocessing step
-            # must be generated user variable, otherwise the variable must have already been added at this stage!
-            if not _is_generated(variable_name):
-                log.warning("UserVariable with name :'" + variable_name + "' does not exist. Creating it now.")
-            catrobat.add_user_variable(self.project, variable_name, self.sprite, self.sprite.getName())
-        user_variable = self.sprite.getUserVariable(variable_name)
+            user_variable = self.project.getUserVariable(variable_name)
 
         assert user_variable is not None and user_variable.getName() == variable_name, \
                "variable: %s, sprite_name: %s" % (variable_name, self.sprite.getName())


### PR DESCRIPTION
Previously, if a global variable was referenced in a sprite (that is not the background), a new local variable with the same name was added to the sprite. As a result the pocket code program could only access the local variant of the variable and scripts didn't work as they were intended to.
Since the background in scratch has no local variables, it serves as a container for all global variables. In the code all global variables are stored in self.project.userVariables and local variables in self.sprite.userVariables. In case a variable within a sprite cant be accessed, it has to be a global one and it has to be referenced correctly, so the script can use it.
In order to prevent confusion in the future, comments were added to explain how to access the variables.