### PR TITLE
STCC restore build_type in default.ini file

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,8 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1011
+build_number:  1020
+build_type:    S2CC
 
 ;-------------------------------------------------------------------------------
 [CATROBAT]


### PR DESCRIPTION
restore the build_type line in default.ini, since its important for testing -> build_type is a key in a dictionary that is accessed while build the xml-header -> fails if this line is not present