### PR TITLE
STCC-207 fixed missing project id for scratch3 projects

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1020
+build_number:  1021
 build_type:    S2CC
 
 ;-------------------------------------------------------------------------------

--- a/src/scratchtocatrobat/main.py
+++ b/src/scratchtocatrobat/main.py
@@ -100,24 +100,25 @@ def run_converter(scratch_project_file_or_url, output_dir,
         progress_bar = helpers.ProgressBar(None, web_mode, sys.stdout)
         with common.TemporaryDirectory(remove_on_exit=temp_rm) as scratch_project_dir:
             is_local_project = True
+            project_id = None
             if scratch_project_file_or_url.startswith("https://"):
                 is_local_project = False
                 validate_scratch_url(scratch_project_file_or_url)
 
-                project_ID = scratchwebapi.extract_project_id_from_url(scratch_project_file_or_url)
-                if not scratchwebapi.request_is_project_available(project_ID):
-                    raise common.ScratchtobatError("Project with ID %s not available" % project_ID)
-                visibility = scratchwebapi.getMetaDataEntry(project_ID, "visibility")
+                project_id = scratchwebapi.extract_project_id_from_url(scratch_project_file_or_url)
+                if not scratchwebapi.request_is_project_available(project_id):
+                    raise common.ScratchtobatError("Project with ID %s not available" % project_id)
+                visibility = scratchwebapi.getMetaDataEntry(project_id, "visibility")
                 if visibility != scratchwebapi.ScratchProjectVisibiltyState.PUBLIC:
                     log.warn('-'*80)
                     log.warn("CAVE: Project with ID %s is NOT a public project!! Trying to " \
                              "continue the conversion-process anyway, but expecting the " \
-                             "conversion to fail or to be incomplete...", project_ID)
+                             "conversion to fail or to be incomplete...", project_id)
                     log.warn('-'*80)
                 log.info("Downloading project from URL: '{}' to temp dir {} ...".format(
                                                 scratch_project_file_or_url, scratch_project_dir))
                 scratchwebapi.download_project(scratch_project_file_or_url, scratch_project_dir, progress_bar)
-                scratch3ProjectName = scratchwebapi.getMetaDataEntry(project_ID, "title")
+                scratch3ProjectName = scratchwebapi.getMetaDataEntry(project_id, "title")
 
             elif os.path.isfile(scratch_project_file_or_url):
                 log.info("Extracting project from path: '{}' ...".format(scratch_project_file_or_url))
@@ -130,11 +131,10 @@ def run_converter(scratch_project_file_or_url, output_dir,
                 log.info("Loading project from path: '{}' ...".format(scratch_project_file_or_url))
                 scratch_project_dir = scratch_project_file_or_url
 
-
             isScratch3Project = scratch3.is_scratch3_project(scratch_project_dir)
 
             if isScratch3Project:
-                scratch3.convert_to_scratch2_data(scratch_project_dir)
+                scratch3.convert_to_scratch2_data(scratch_project_dir, project_id)
 
             project = scratch.Project(scratch_project_dir, progress_bar=progress_bar, is_local_project = is_local_project)
             if isScratch3Project:

--- a/src/scratchtocatrobat/scratch/scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3.py
@@ -193,9 +193,12 @@ def is_scratch3_project(scratch_project_dir):
             else:
                 return False
 
-def convert_to_scratch2_data(scratch_project_dir):
+def convert_to_scratch2_data(scratch_project_dir, project_id):
     parser = Scratch3Parser(os.path.join(scratch_project_dir, helpers.config.get("SCRATCH", "code_file_name")), scratch_project_dir)
     scratch2Data = parser.parse_sprites()
+    assert "info" in scratch2Data
+    assert "projectID" not in scratch2Data["info"]
+    scratch2Data["info"]["projectID"] = project_id
     with open(os.path.join(scratch_project_dir, helpers.config.get("SCRATCH", "code_file_name")), 'w') as json_file:
         json_file.flush()
         json.dump(scratch2Data, json_file, sort_keys=True, indent=4, separators=(',', ': '))

--- a/src/scratchtocatrobat/scratch/test_scratchwebapi.py
+++ b/src/scratchtocatrobat/scratch/test_scratchwebapi.py
@@ -270,10 +270,12 @@ class WebApiTest(common_testing.BaseTestCase):
             result_folder_path = self._testresult_folder_path
             scratchwebapi.download_project(project_url, result_folder_path)
             if scratch3.is_scratch3_project(result_folder_path):
-                scratch3.convert_to_scratch2_data(result_folder_path)
+                scratch3.convert_to_scratch2_data(result_folder_path, project_id)
 
             # TODO: replace with verifying function
-            assert scratch.Project(result_folder_path) is not None
+            project = scratch.Project(result_folder_path)
+            assert project is not None
+            assert project.project_id == project_id
 
     def test_fail_download_project_on_wrong_url(self):
         for wrong_url in ['http://www.tugraz.at', 'http://www.ist.tugraz.at/', 'http://scratch.mit.edu/', 'http://scratch.mit.edu/projects']:
@@ -286,7 +288,7 @@ class WebApiTest(common_testing.BaseTestCase):
             for _project_url, project_id in common_testing.TEST_PROJECT_URL_TO_ID_MAP.iteritems():
                 scratchwebapi.download_project_code(project_id, temp_dir)
                 if scratch3.is_scratch3_project(temp_dir):
-                    scratch3.convert_to_scratch2_data(temp_dir)
+                    scratch3.convert_to_scratch2_data(temp_dir, project_id)
                 project_file_path = os.path.join(temp_dir, scratch._PROJECT_FILE_NAME)
                 with open(project_file_path, 'r') as project_code_file:
                     project_code_content = project_code_file.read()


### PR DESCRIPTION
The xml files of converted scratch3 projects did not include the correct srcatch project id, because the fields where it's extracted in a scratch2 project don't exist anymore. By saving the project id from the url it still can be provided to scratch3 projects.