### PR TITLE
STCC-140 handling of FormulaElement in sound bricks

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -4,7 +4,7 @@ name:          Scratch2Catrobat Converter
 short_name:    S2CC
 version:       0.10.0
 build_name:    Aegean cat
-build_number:  1020
+build_number:  1023
 build_type:    S2CC
 
 ;-------------------------------------------------------------------------------


### PR DESCRIPTION
The ticket contains outdated information about the problems with the sound bricks. The code for this ticket includes some warnings, that tell the programmer what exactly went wrong during the conversion of these sound bricks. Currently there are 3 possible conversion warnings:

1. The sound list in scratch is empty and no sound can be played
2. The parameter for the brick is a formula or a variable, which is not yet handled in Pocket Code
3. The sound from the drop down menu is not available anymore (possible if the sound is deleted, after it was selected in the drop down menu)

In the last 2 cases, if the sound list is not empty, the first sound in the list will be selected instead.

A new ticket with detailed information for the sound bricks will be created.