### PR TITLE
STCC-252 web requirements file

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,0 +1,3 @@
+rq<=0.11
+redis<3
+tornado<5


### PR DESCRIPTION
Added requirements file in web/
The correct library versions for the webserver can be installed with:
pip2 install -r web/requirements.txt