### PR TITLE
STCC-126 fixed the order of sprites in Scratch2 and Scratch3 projects

### DIFF
--- a/src/scratchtocatrobat/converter/test_converter.py
+++ b/src/scratchtocatrobat/converter/test_converter.py
@@ -3117,7 +3117,7 @@ class TestShowVariablesWorkaround(unittest.TestCase):
         assert self.default_scene
         sprite_list = self.default_scene.getSpriteList()
         self.assertEqual(6, len(sprite_list))
-        [self.stage_sprite, self.sprite1, self.sprite2, self.global_slider_sprite, self.local_slider_sprite, self.toggle_slider_sprite] = sprite_list
+        [self.stage_sprite, self.sprite2, self.sprite1, self.global_slider_sprite, self.toggle_slider_sprite, self.local_slider_sprite] = sprite_list
 
     def test_sprite1_correct_events_added(self):
         #Sprite1

--- a/src/scratchtocatrobat/scratch/scratch.py
+++ b/src/scratchtocatrobat/scratch/scratch.py
@@ -533,7 +533,7 @@ class RawProject(Object):
         raw_variables_and_sensors_data = filter(lambda var: "target" in var, self.get_children())
 
         self.raw_objects = sorted(filter(lambda obj_data: "objName" in obj_data, self.get_children()),
-                                  key=lambda obj_data: obj_data.get("indexInLibrary", 0))
+                                  key=lambda obj_data: obj_data.get("indexInLibrary", 0), reverse=True)
         self.objects = [Object(raw_object) for raw_object in [dict_] + self.raw_objects]
         self.objects_map = {obj.name: obj for obj in self.objects}
         stage_list = [raw_object["objName"] for raw_object in [dict_] + self.raw_objects if "isStage" in raw_object and raw_object["isStage"]]

--- a/src/scratchtocatrobat/scratch/scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3.py
@@ -272,7 +272,7 @@ class Scratch3Parser(object):
             scratch2ProjectDict["direction"] = sprite["direction"]
             scratch2ProjectDict["rotationStyle"] = sprite["rotationStyle"]
             scratch2ProjectDict["isDraggable"] = sprite["draggable"]
-            # scratch2ProjectDict["indexInLibrary"] = sprite["indexInLibrary"]
+            scratch2ProjectDict["indexInLibrary"] = -sprite["layerOrder"] #layerOrder is reversed to indexInLayer
             # scratch2ProjectDict["spriteInfo"] = sprite["spriteInfo"]
             scratch2ProjectDict["visible"] = sprite["visible"]
 

--- a/src/scratchtocatrobat/scratch/test_scratch.py
+++ b/src/scratchtocatrobat/scratch/test_scratch.py
@@ -187,7 +187,7 @@ class TestRawProjectFunc(unittest.TestCase):
             assert scratch_object
             assert isinstance(scratch_object, scratch.Object)
         assert self.project.objects[0].name == scratch.STAGE_OBJECT_NAME, "Stage object missing"
-        assert [_.name for _ in self.project.objects] == ['Stage', 'Sprite1', 'Cassy Dance']
+        assert [_.name for _ in self.project.objects] == ['Stage', 'Cassy Dance', 'Sprite1']
 
     def test_can_access_project_variables(self):
         variables_test_code_content = common.content_of(common_testing.get_test_resources_path("scratch_code_only", "variables_test.json"))
@@ -203,8 +203,8 @@ class TestProjectOrderedObjects(unittest.TestCase):
         self.project_without_object_indexes = scratch.Project(common_testing.get_test_project_path("dress_up_tera_without_object_indexes"))
 
     def test_are_scratch_objects_ordered_by_library_index_correctly(self):
-        expected_sorted_object_names = ["Stage", "Cape", "Tera", "Mask", "Hat", "Blouse",
-                                        "Tshirt", "Wings", "Antennae"]
+        expected_sorted_object_names = ["Stage", "Antennae", "Wings", "Tshirt", "Blouse", "Hat",
+                                        "Mask", "Tera", "Cape"]
         assert len(expected_sorted_object_names) == len(self.project_with_object_indexes.objects)
         for idx, scratch_object in enumerate(self.project_with_object_indexes.objects):
             assert scratch_object

--- a/src/scratchtocatrobat/tools/common_testing.py
+++ b/src/scratchtocatrobat/tools/common_testing.py
@@ -44,13 +44,12 @@ from scratchtocatrobat.converter import converter
 assert System.getProperty("python.security.respectJavaAccessibility") == 'false', "Jython registry property 'python.security.respectJavaAccessibility' must be set to 'false'"
 
 TEST_PROJECT_URL_TO_ID_MAP = {
-    # scratch2 projects
+    # These projects are all Scratch3 projects now.
     'https://scratch.mit.edu/projects/390299427/':   '390299427',  # dance back
     # FIXME: fails with error 'http://scratch.mit.edu/projects/10189712/': '10189712',  # kick the ball
     'https://scratch.mit.edu/projects/390300019/':   '390300019',  # dancing in the castle
     'https://scratch.mit.edu/projects/390300135/':   '390300135',  # cat has message
     'https://scratch.mit.edu/projects/390300261/':   '390300261',  # jai ho!
-    # scratch3 projects
     'https://scratch.mit.edu/projects/390300374/':  '390300374',  # simple memory
     'https://scratch.mit.edu/projects/390300542/':  '390300542',  # same image, different objects
 }


### PR DESCRIPTION
The order of sprites added to the catrobat project had to be reversed.

'BuildOrder' in Scratch3 projects is also considered now and converted to the 'indexInLibrary' property of the intermediate Scratch2 project.

Test projects:
https://scratch.mit.edu/projects/201274654/
https://scratch.mit.edu/projects/333674907/
https://scratch.mit.edu/projects/11656680/
https://scratch.mit.edu/projects/384277232/