### PR TITLE
STCC-230 fixed catrobat program crash if not supported brick in stage of Scratch3 projects

### DIFF
--- a/src/scratchtocatrobat/scratch/scratch3visitor/test_scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/test_scratch3.py
@@ -1327,5 +1327,17 @@ class TestScratch3Blocks(unittest.TestCase):
         assert converted_block[1] == "teststring"
 
 
+    ### Unsupported block testcase ###################
+    def test_unsupportedBlock(self):
+        context = create_block_context("not_supported_block")
+        testblock = context.block
+        addInputOfType(testblock, "STRING", LiteralType.STRING)
+
+        converted_block = visitBlock(context)
+
+        assert converted_block[0] == "note:"
+        assert converted_block[1] == "ERROR: BLOCK NOT FOUND: not_supported_block"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/scratchtocatrobat/scratch/scratch3visitor/visitorUtil.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/visitorUtil.py
@@ -85,7 +85,7 @@ def visitGeneric(blockcontext, attributename):
 
 def visitDefault(blockcontext):
     log.warn("block not yet implemented: " + blockcontext.block.opcode)
-    return ["say:", "ERROR: BLOCK NOT FOUND: " + blockcontext.block.opcode]
+    return ["note:", "ERROR: BLOCK NOT FOUND: " + blockcontext.block.opcode]
 
 def visitCondition(blockcontext):
     block = blockcontext.block


### PR DESCRIPTION
If a block in a Scratch3 project was not implemented yet it was replaced with a say-brick. say-bricks are not supported in stage in catrobat projects. 
The say-brick was replaced with a note-brick, which works fine for sprites and stage.
Also added a unit test.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines) (Replace occurences of CATROBAT or CAT with STCC)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Post a message in the *#stcc* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer