### PR TITLE
STCC-265 Index Out of Range Error handled in scratch.py in is_valid_script_input[WM, SS]

### DIFF
--- a/src/scratchtocatrobat/scratch/scratch.py
+++ b/src/scratchtocatrobat/scratch/scratch.py
@@ -1025,11 +1025,13 @@ class Script(object):
     @classmethod
     def is_valid_script_input(cls, json_input):
         are_all_positional_values_numbers = all(isinstance(positional_value, (int, float)) for positional_value in json_input[0:2])
-        if (isinstance(json_input, list) and len(json_input) == 3 and are_all_positional_values_numbers and isinstance(json_input[2], list)):
-            # NOTE: could use a json validator instead
-            script_content = json_input[2]
-            if script_content[0][0] in SCRIPTS:
-                return True
+        try:
+            if (isinstance(json_input, list) and len(json_input) == 3 and are_all_positional_values_numbers and isinstance(json_input[2], list)):
+                script_content = json_input[2]
+                if script_content[0][0] in SCRIPTS:
+                    return True
+        except:
+            raise ScriptError("Not valid script input")
         return False
 
     def get_type(self):

--- a/src/scratchtocatrobat/scratch/test_scratch.py
+++ b/src/scratchtocatrobat/scratch/test_scratch.py
@@ -302,6 +302,12 @@ class TestScriptInit(unittest.TestCase):
             with self.assertRaises(scratch.ScriptError):
                 scratch.Script(faulty_input)
 
+    def test_fail_with_no_multi_list_on_third_param(self):
+        faulty_input = [
+            1,
+            1,
+            [u'']]
+        self.assertRaises(scratch.ScriptError, lambda: scratch.Script.is_valid_script_input(faulty_input))
 
 class TestScriptFunc(unittest.TestCase):
 


### PR DESCRIPTION
…cript_input [WM, SS]

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines) (Replace occurences of CATROBAT or CAT with STCC)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Post a message in the *#stcc* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
