### PR TITLE
[STCC-285] Scratch3 block "next backdrop" can be converted now!

### DIFF
--- a/src/scratchtocatrobat/scratch/scratch3visitor/looks.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/looks.py
@@ -33,8 +33,7 @@ def visitSwitchbackdropto(blockcontext):
     return ["startScene", backdrop]
 
 def visitNextbackdrop(blockcontext):
-    log.warn("[Scratch3] block {} ({}) possibly not available in Scratch2".format(blockcontext.block.opcode, blockcontext.block.name))
-    return ["nextBackdropPlaceholder"] #TODO: not in scratch2
+    return ["nextCostume"]
 
 def visitChangesizeby(blockcontext):
     size = visitGeneric(blockcontext, "CHANGE")


### PR DESCRIPTION
Scratch3 block "next backdrop" is now functioning. 
Scratch3 project to test it: 434088179.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines) (Replace occurences of CATROBAT or CAT with STCC)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Post a message in the *#stcc* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
