### PR TITLE
[STCC-293] Refactor Blockmapping.py

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -23,6 +23,8 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+
+import atexit
 import os
 import platform
 import subprocess
@@ -67,6 +69,21 @@ for subdir, dirs, files in os.walk(test_folder_path):
     for file in files:
         files_in_test_folders.append(subdir + "/" + file)
 
+
+# deleting all generated files
+def delete_files():
+    print("-" * 80)
+    print("Deleting all test generated files")
+    print()
+    for subdir, dirs, files in os.walk(test_folder_path):
+        for file in files:
+            if not files_in_test_folders.__contains__(subdir + "/" + file):
+                print("Deleting: " + subdir + "/" + file)
+                os.remove(subdir + "/" + file)
+
+
+atexit.register(delete_files)
+
 if len(sys.argv) >= 2 and sys.argv[1] != "all":
     if (isinstance(sys.argv[1], str) or isinstance(sys.argv[1], unicode)) and sys.argv[1].startswith("test_"):
         argument = sys.argv[1] if sys.argv[1].endswith('.py') else sys.argv[1] + ".py"
@@ -78,11 +95,10 @@ if len(sys.argv) >= 2 and sys.argv[1] != "all":
 else:
     print("Testing all modules!")
 
-
 for module in modules_under_test:
-    print("-"*80)
+    print("-" * 80)
     print("Testing '%s':" % module)
-    print("-"*80)
+    print("-" * 80)
     exec_args = [jython_exec_path, "-m", module[:-3]]
 
     if len(sys.argv) >= 3:
@@ -92,14 +108,5 @@ for module in modules_under_test:
         sys.exit(exit_code)
     print()
     print()
-
-print("-"*80)
-print("Deleting all test generated files")
-print()
-for subdir, dirs, files in os.walk(test_folder_path):
-    for file in files:
-        if not files_in_test_folders.__contains__(subdir + "/" + file):
-            print("Deleting: " + subdir + "/" + file)
-            os.remove(subdir + "/" + file)
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/run_tests
+++ b/run_tests
@@ -27,6 +27,9 @@ import os
 import platform
 import subprocess
 import sys
+import threading
+import time
+
 sys.path.append(os.path.join(os.path.realpath(os.path.dirname(__file__)), "src"))
 from scratchtocatrobat.tools import helpers
 
@@ -37,6 +40,9 @@ helpers.make_dir_if_not_exists(data_dirs)
 env = os.environ
 env['JYTHONPATH'] = jython_path if sys.platform != 'win32' else jython_path.replace(":", ";")
 
+test_folder_path = 'test/res/scratch'
+if not os.path.exists(test_folder_path):
+    helpers.error("Test folder does not exist")
 if not os.path.isdir(jython_home_dir):
     helpers.error("Invalid jython home path given. No valid directory. Please update 'jython_home' in the config file.")
 if not os.path.isfile(jython_exec_path):
@@ -55,6 +61,12 @@ for subdir, dirs, files in os.walk(helpers.SRC_PATH):
             test_module_name = relative_subdir_path.replace(os.sep, ".") + "." + file
             modules_under_test.add(test_module_name)
 
+# checking all existing files
+files_in_test_folders = list()
+for subdir, dirs, files in os.walk(test_folder_path):
+    for file in files:
+        files_in_test_folders.append(file)
+
 if len(sys.argv) >= 2 and sys.argv[1] != "all":
     if (isinstance(sys.argv[1], str) or isinstance(sys.argv[1], unicode)) and sys.argv[1].startswith("test_"):
         argument = sys.argv[1] if sys.argv[1].endswith('.py') else sys.argv[1] + ".py"
@@ -65,6 +77,7 @@ if len(sys.argv) >= 2 and sys.argv[1] != "all":
         helpers.error("Invalid input given! Module name must always start with 'test_' (e.g. 'test_scratch')")
 else:
     print("Testing all modules!")
+
 
 for module in modules_under_test:
     print("-"*80)
@@ -79,5 +92,17 @@ for module in modules_under_test:
         sys.exit(exit_code)
     print()
     print()
+
+
+# Erase all generated files
+print("-"*80)
+print("Deleting all test generated files")
+
+for subdir, dirs, files in os.walk(test_folder_path):
+    for file in files:
+        if not files_in_test_folders.__contains__(file):
+            print("Deleting: " + subdir + "/" + file)
+            os.remove(subdir + "/" + file)
+
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/run_tests
+++ b/run_tests
@@ -65,7 +65,7 @@ for subdir, dirs, files in os.walk(helpers.SRC_PATH):
 files_in_test_folders = list()
 for subdir, dirs, files in os.walk(test_folder_path):
     for file in files:
-        files_in_test_folders.append(file)
+        files_in_test_folders.append(subdir + "/" + file)
 
 if len(sys.argv) >= 2 and sys.argv[1] != "all":
     if (isinstance(sys.argv[1], str) or isinstance(sys.argv[1], unicode)) and sys.argv[1].startswith("test_"):
@@ -106,9 +106,8 @@ else:
     print("Deleting all test generated files")
     for subdir, dirs, files in os.walk(test_folder_path):
         for file in files:
-            # print("Checking " + subdir + "/" + file)
-            if not files_in_test_folders.__contains__(file):
+            if not files_in_test_folders.__contains__(subdir + "/" + file):
                 print("Deleting: " + subdir + "/" + file)
-                print(os.remove(subdir + "/" + file))
+                os.remove(subdir + "/" + file)
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/run_tests
+++ b/run_tests
@@ -94,15 +94,21 @@ for module in modules_under_test:
     print()
 
 
-# Erase all generated files
-print("-"*80)
-print("Deleting all test generated files")
+pid = os.fork()
 
-for subdir, dirs, files in os.walk(test_folder_path):
-    for file in files:
-        if not files_in_test_folders.__contains__(file):
-            print("Deleting: " + subdir + "/" + file)
-            os.remove(subdir + "/" + file)
-
+if pid > 0:
+    print("This is written by the parent process {}".format(os.getpid()))
+else:
+    time.sleep(15)
+    print("This is written by the child process {}".format(os.getpid()))
+    # Erase all generated files
+    print("-"*80)
+    print("Deleting all test generated files")
+    for subdir, dirs, files in os.walk(test_folder_path):
+        for file in files:
+                print("Checking " + subdir + "/" + file)
+            if not files_in_test_folders.__contains__(file):
+                print("Deleting: " + subdir + "/" + file)
+                os.remove(subdir + "/" + file)
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/run_tests
+++ b/run_tests
@@ -26,11 +26,8 @@ from __future__ import print_function
 
 import atexit
 import os
-import platform
 import subprocess
 import sys
-import threading
-import time
 
 sys.path.append(os.path.join(os.path.realpath(os.path.dirname(__file__)), "src"))
 from scratchtocatrobat.tools import helpers

--- a/run_tests
+++ b/run_tests
@@ -106,7 +106,7 @@ else:
     print("Deleting all test generated files")
     for subdir, dirs, files in os.walk(test_folder_path):
         for file in files:
-                print("Checking " + subdir + "/" + file)
+            print("Checking " + subdir + "/" + file)
             if not files_in_test_folders.__contains__(file):
                 print("Deleting: " + subdir + "/" + file)
                 os.remove(subdir + "/" + file)

--- a/run_tests
+++ b/run_tests
@@ -93,21 +93,13 @@ for module in modules_under_test:
     print()
     print()
 
-
-pid = os.fork()
-
-if pid > 0:
-    print("This is written by the parent process {}".format(os.getpid()))
-else:
-    time.sleep(15)
-    print("This is written by the child process {}".format(os.getpid()))
-    # Erase all generated files
-    print("-"*80)
-    print("Deleting all test generated files")
-    for subdir, dirs, files in os.walk(test_folder_path):
-        for file in files:
-            if not files_in_test_folders.__contains__(subdir + "/" + file):
-                print("Deleting: " + subdir + "/" + file)
-                os.remove(subdir + "/" + file)
+print("-"*80)
+print("Deleting all test generated files")
+print()
+for subdir, dirs, files in os.walk(test_folder_path):
+    for file in files:
+        if not files_in_test_folders.__contains__(subdir + "/" + file):
+            print("Deleting: " + subdir + "/" + file)
+            os.remove(subdir + "/" + file)
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/run_tests
+++ b/run_tests
@@ -106,9 +106,9 @@ else:
     print("Deleting all test generated files")
     for subdir, dirs, files in os.walk(test_folder_path):
         for file in files:
-            print("Checking " + subdir + "/" + file)
+            # print("Checking " + subdir + "/" + file)
             if not files_in_test_folders.__contains__(file):
                 print("Deleting: " + subdir + "/" + file)
-                os.remove(subdir + "/" + file)
+                print(os.remove(subdir + "/" + file))
 
 sys.exit(helpers.ExitCode.SUCCESS)

--- a/src/scratchtocatrobat/scratch/scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3.py
@@ -167,7 +167,7 @@ class Scratch3Parser(object):
             }
         else:
             #sb3 has same opcode for background # and name, sb2 has two different opcodes => decide opcode depending on param
-            if monitor["opcode"] == "looks_backdropnumbername":
+            if monitor["opcode"] == opcodes.LOOKS_BACK_DROP_NUMBER_NAME:
                 if monitor.get("params", {}).get("NUMBER_NAME") == "name":
                     monitor["opcode"] = "looks_backdropname"
                 else:

--- a/src/scratchtocatrobat/scratch/scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3.py
@@ -1,4 +1,7 @@
+
+
 from scratchtocatrobat.tools import logger, helpers
+from scratchtocatrobat.scratch.scratch3visitor.scratch2_json_format import Scratch3_2Opcodes as opcodes
 import os
 import json
 
@@ -175,7 +178,7 @@ class Scratch3Parser(object):
                 return None
             target = monitor.get("spriteName", None)
             param = (MONITOR_PARAM_MAPPING[monitor["opcode"]](monitor["params"]) if monitor["opcode"] in MONITOR_PARAM_MAPPING else None)
-            if monitor["opcode"] in ["data_variable", "sensing_current"]:
+            if monitor["opcode"] in ["data_variable", opcodes.SENSING_CURRENT]:
                 label = param
             else:
                 label = MONITOR_LABEL_MAPPING[monitor["opcode"]]

--- a/src/scratchtocatrobat/scratch/scratch3visitor/blockmapping.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/blockmapping.py
@@ -1,170 +1,171 @@
 import looks, motion, event, sensing, sound, operator, control, data, pen
+from scratchtocatrobat.scratch.scratch3visitor.scratch2_json_format import Scratch3_2Opcodes as opcodes
 
 visitormap = {
     ### event blocks ####
-    "FLAG_CLICKED": event.visitWhenflagclicked,  # tested
-    "BROADCAST": event.visitBroadcast,  # tested
-    "BROADCAST_AND_WAIT": event.visitBroadcastandwait,  # tested
-    "KEY_PRESSED": event.visitWhenkeypressed,  # tested
-    "SPRITE_CLICKED": event.visitWhenthisspriteclicked,  # tested
-    "GREATER_THAN": event.visitWhengreaterthan,  # tested
-    "BACKDROP_SWITCHED_TO": event.visitWhenbackdropswitchesto,  # tested
-    "BROADCAST_RECEIVED": event.visitWhenbroadcastreceived,  # tested
+    opcodes.FLAG_CLICKED: event.visitWhenflagclicked,  # tested
+    opcodes.BROADCAST: event.visitBroadcast,  # tested
+    opcodes.BROADCAST_AND_WAIT: event.visitBroadcastandwait,  # tested
+    opcodes.KEY_PRESSED: event.visitWhenkeypressed,  # tested
+    opcodes.SPRITE_CLICKED: event.visitWhenthisspriteclicked,  # tested
+    opcodes.GREATER_THAN: event.visitWhengreaterthan,  # tested
+    opcodes.BACKDROP_SWITCHED_TO: event.visitWhenbackdropswitchesto,  # tested
+    opcodes.BROADCAST_RECEIVED: event.visitWhenbroadcastreceived,  # tested
 
     ### motion blocks ####
-    "MOTION_MOVE_STEPS": motion.visitMovesteps,  # tested
-    "MOTION_TURN_RIGHT": motion.visitTurnright,  # tested
-    "MOTION_TURN_LEFT": motion.visitTurnleft,  # tested
-    "MOTION_GOTO": motion.visitGoto,  # tested
-    "MOTION_GOTO_XY": motion.visitGotoxy,  # tested
-    "MOTION_GLIDE_TO": motion.visitGlideto,  # tested
-    "MOTION_GLIDE_SECS_TO_XY": motion.visitGlidesecstoxy,  # tested
-    "MOTION_POINT_IN_DIR": motion.visitPointindirection,  # tested
-    "MOTION_POINT_TOWARDS": motion.visitPointtowards,  # tested
-    "MOTION_CHANGE_BY_XY": motion.visitChangexby,  # tested
-    "MOTION_SET_X": motion.visitSetx,  # tested
-    "MOTION_CHANGE_Y_BY": motion.visitChangeyby,  # tested
-    "MOTION_SET_Y": motion.visitSety,  # tested
-    "MOTION_BOUNCE_OFF_EDGE": motion.visitIfonedgebounce,  # tested
-    "MOTION_SET_ROTATIONSTYLE": motion.visitSetrotationstyle,  # tested
-    "MOTION_GOTO_MENU": motion.visitGoto_menu,  # tested
-    "MOTION_GLIDE_TO_MENU": motion.visitGlideto_menu,  # tested
-    "MOTION_POINT_TOWARDS_MENU": motion.visitPointtowards_menu,  # tested
-    "MOTION_DIR": motion.visitDirection,  # tested
-    "MOTION_Y_POS": motion.visitYposition,  # tested
-    "MOTION_X_POS": motion.visitXposition,  # tested
+    opcodes.MOTION_MOVE_STEPS: motion.visitMovesteps,  # tested
+    opcodes.MOTION_TURN_RIGHT: motion.visitTurnright,  # tested
+    opcodes.MOTION_TURN_LEFT: motion.visitTurnleft,  # tested
+    opcodes.MOTION_GOTO: motion.visitGoto,  # tested
+    opcodes.MOTION_GOTO_XY: motion.visitGotoxy,  # tested
+    opcodes.MOTION_GLIDE_TO: motion.visitGlideto,  # tested
+    opcodes.MOTION_GLIDE_SECS_TO_XY: motion.visitGlidesecstoxy,  # tested
+    opcodes.MOTION_POINT_IN_DIR: motion.visitPointindirection,  # tested
+    opcodes.MOTION_POINT_TOWARDS: motion.visitPointtowards,  # tested
+    opcodes.MOTION_CHANGE_BY_XY: motion.visitChangexby,  # tested
+    opcodes.MOTION_SET_X: motion.visitSetx,  # tested
+    opcodes.MOTION_CHANGE_Y_BY: motion.visitChangeyby,  # tested
+    opcodes.MOTION_SET_Y: motion.visitSety,  # tested
+    opcodes.MOTION_BOUNCE_OFF_EDGE: motion.visitIfonedgebounce,  # tested
+    opcodes.MOTION_SET_ROTATIONSTYLE: motion.visitSetrotationstyle,  # tested
+    opcodes.MOTION_GOTO_MENU: motion.visitGoto_menu,  # tested
+    opcodes.MOTION_GLIDE_TO_MENU: motion.visitGlideto_menu,  # tested
+    opcodes.MOTION_POINT_TOWARDS_MENU: motion.visitPointtowards_menu,  # tested
+    opcodes.MOTION_DIR: motion.visitDirection,  # tested
+    opcodes.MOTION_Y_POS: motion.visitYposition,  # tested
+    opcodes.MOTION_X_POS: motion.visitXposition,  # tested
 
     ### look blocks ####
-    "LOOKS_SAY_FOR_SECS": looks.visitSayforsecs,  # tested
-    "LOOKS_SAY": looks.visitSay,  # tested
-    "LOOKS_THINK_FOR_SECS": looks.visitThinkforsecs,  # tested
-    "LOOKS_THINK": looks.visitThink,  # tested
-    "LOOKS_SWITCH_COSTUME_TO": looks.visitSwitchcostumeto,  # tested
-    "LOOKS_NEXT_COSTUME": looks.visitNextcostume,  # tested
-    "LOOKS_SWITCH_BACKDROP_TO": looks.visitSwitchbackdropto,  # tested
-    "LOOKS_NEXT_BACKDROP": looks.visitNextbackdrop,  # tested
-    "LOOKS_CHANGE_SIZE_BY": looks.visitChangesizeby,  # tested
-    "LOOKS_SET_SIZE_TO": looks.visitSetsizeto,  # tested
-    "LOOKS_CHANGE_EFFECT_BY": looks.visitChangeeffectby,  # tested
-    "LOOKS_SET_EFFECT_TO": looks.visitSeteffectto,  # tested
-    "LOOKS_CLEAR_EFFECTS": looks.visitCleargraphiceffects,  # tested
-    "LOOKS_SHOW": looks.visitShow,  # tested
-    "LOOKS_HIDE": looks.visitHide,  # tested
-    "LOOKS_GOTO_FRONT_BACK": looks.visitGotofrontback,  # tested
-    "LOOKS_FORWARD_BACKWARD_LAYERS": looks.visitGoforwardbackwardlayers,  # tested by fleischhacker
-    "LOOKS_COSTUME": looks.visitCostume,  # tested
-    "LOOKS_BACKDROPS": looks.visitBackdrops,  # tested
-    "LOOKS_COSTUME_NUMBER_NAME": looks.visitCostumenumbername,  # tested
-    "LOOKS_SIZE": looks.visitSize,  # tested
-    "looks_backdropnumbername": looks.visitBackdropnumbername,
+    opcodes.LOOKS_SAY_FOR_SECS: looks.visitSayforsecs,  # tested
+    opcodes.LOOKS_SAY: looks.visitSay,  # tested
+    opcodes.LOOKS_THINK_FOR_SECS: looks.visitThinkforsecs,  # tested
+    opcodes.LOOKS_THINK: looks.visitThink,  # tested
+    opcodes.LOOKS_SWITCH_COSTUME_TO: looks.visitSwitchcostumeto,  # tested
+    opcodes.LOOKS_NEXT_COSTUME: looks.visitNextcostume,  # tested
+    opcodes.LOOKS_SWITCH_BACKDROP_TO: looks.visitSwitchbackdropto,  # tested
+    opcodes.LOOKS_NEXT_BACKDROP: looks.visitNextbackdrop,  # tested
+    opcodes.LOOKS_CHANGE_SIZE_BY: looks.visitChangesizeby,  # tested
+    opcodes.LOOKS_SET_SIZE_TO: looks.visitSetsizeto,  # tested
+    opcodes.LOOKS_CHANGE_EFFECT_BY: looks.visitChangeeffectby,  # tested
+    opcodes.LOOKS_SET_EFFECT_TO: looks.visitSeteffectto,  # tested
+    opcodes.LOOKS_CLEAR_EFFECTS: looks.visitCleargraphiceffects,  # tested
+    opcodes.LOOKS_SHOW: looks.visitShow,  # tested
+    opcodes.LOOKS_HIDE: looks.visitHide,  # tested
+    opcodes.LOOKS_GOTO_FRONT_BACK: looks.visitGotofrontback,  # tested
+    opcodes.LOOKS_FORWARD_BACKWARD_LAYERS: looks.visitGoforwardbackwardlayers,  # tested by fleischhacker
+    opcodes.LOOKS_COSTUME: looks.visitCostume,  # tested
+    opcodes.LOOKS_BACKDROPS: looks.visitBackdrops,  # tested
+    opcodes.LOOKS_COSTUME_NUMBER_NAME: looks.visitCostumenumbername,  # tested
+    opcodes.LOOKS_SIZE: looks.visitSize,  # tested
+    opcodes.LOOKS_BACK_DROP_NUMBER_NAME: looks.visitBackdropnumbername,
 
     ### sound blocks ####
-    "SOUNDS_PLAY": sound.visitPlay,  # tested
-    "SOUNDS_PLAY_UNTIL_DONE": sound.visitPlayuntildone,  # tested
-    "SOUNDS_STOP_ALL": sound.visitStopallsounds,  # tested
+    opcodes.SOUNDS_PLAY: sound.visitPlay,  # tested
+    opcodes.SOUNDS_PLAY_UNTIL_DONE: sound.visitPlayuntildone,  # tested
+    opcodes.SOUNDS_STOP_ALL: sound.visitStopallsounds,  # tested
     "sound_changeeffectby": sound.visitChangeeffectby,  # TODO not implemented in catrobat yet
     "sound_seteffectto": sound.visitSeteffectto,  # TODO not implemented in catrobat yet
     "sound_cleareffects": sound.visitCleareffects,  # TODO not implemented in scratch2, workaroundq
-    "SOUNDS_CHANGE_VOLUME_BY": sound.visitChangevolumeby,  # tested
-    "SOUNDS_SET_VOLUME_TO": sound.visitSetvolumeto,  # tested
-    "SOUNDS_MENU": sound.visitSounds_menu,  # tested
-    "SOUNDS_VOLUME": sound.visitVolume,  # tested
+    opcodes.SOUNDS_CHANGE_VOLUME_BY: sound.visitChangevolumeby,  # tested
+    opcodes.SOUNDS_SET_VOLUME_TO: sound.visitSetvolumeto,  # tested
+    opcodes.SOUNDS_MENU: sound.visitSounds_menu,  # tested
+    opcodes.SOUNDS_VOLUME: sound.visitVolume,  # tested
 
     ### control blocks ####
-    "CONTROL_WAIT": control.visitWait,  # tested
-    "CONTROL_REPEAT": control.visitRepeat,  # tested
-    "CONTROL_IF": control.visitIf,  # tested
-    "CONTROL_IF_ELSE": control.visitIf_else,  # tested
-    "CONTROL_WAIT_UNTIL": control.visitWait_until,  # tested
-    "CONTROL_REPEAT_UNTIL": control.visitRepeat_until,  # tested
-    "CONTROL_CREATE_CLONE_OF": control.visitCreate_clone_of,  # tested
-    "CONTROL_CREATE_CLONE_OF_MENU": control.visitCreate_clone_of_menu,  # tested
-    "CONTROL_STOP": control.visitStop,  # tested
-    "CONTROL_START_AS_CLONE": control.visitStart_as_clone,  # tested
-    "CONTROL_FOREVER": control.visitForever,  # tested
-    "CONTROL_DELETE_THIS_CLONE": control.visitDelete_this_clone,  # tested
-    "CONTROL_PROCEDURES_CALL": control.visitProcedures_call,  # tested
-    "CONTROL_PROCEDURES_DEFINITION": control.visitProcedures_definition,  # tested
-    "CONTROL_ARGUMENT_REPORTER_STRING": control.visitArgumentIntOrString,  # tested
-    "CONTROL_ARGUMENT_REPORTER_BOOL": control.visitArgumentBool,  # tested
-    "CONTROL_PROCEDURES_PROTOTYPE": control.visitProcedures_prototype,  # tested
+    opcodes.CONTROL_WAIT: control.visitWait,  # tested
+    opcodes.CONTROL_REPEAT: control.visitRepeat,  # tested
+    opcodes.CONTROL_IF: control.visitIf,  # tested
+    opcodes.CONTROL_IF_ELSE: control.visitIf_else,  # tested
+    opcodes.CONTROL_WAIT_UNTIL: control.visitWait_until,  # tested
+    opcodes.CONTROL_REPEAT_UNTIL: control.visitRepeat_until,  # tested
+    opcodes.CONTROL_CREATE_CLONE_OF: control.visitCreate_clone_of,  # tested
+    opcodes.CONTROL_CREATE_CLONE_OF_MENU: control.visitCreate_clone_of_menu,  # tested
+    opcodes.CONTROL_STOP: control.visitStop,  # tested
+    opcodes.CONTROL_START_AS_CLONE: control.visitStart_as_clone,  # tested
+    opcodes.CONTROL_FOREVER: control.visitForever,  # tested
+    opcodes.CONTROL_DELETE_THIS_CLONE: control.visitDelete_this_clone,  # tested
+    opcodes.CONTROL_PROCEDURES_CALL: control.visitProcedures_call,  # tested
+    opcodes.CONTROL_PROCEDURES_DEFINITION: control.visitProcedures_definition,  # tested
+    opcodes.CONTROL_ARGUMENT_REPORTER_STRING: control.visitArgumentIntOrString,  # tested
+    opcodes.CONTROL_ARGUMENT_REPORTER_BOOL: control.visitArgumentBool,  # tested
+    opcodes.CONTROL_PROCEDURES_PROTOTYPE: control.visitProcedures_prototype,  # tested
 
     ### sensing blocks ####
-    "SENSING_ASK_AND_WAIT": sensing.visitAskandwait,  # tested
-    "SENSING_SET_DRAG_MODE": sensing.visitSetdragmode,  # tested
-    "SENSING_RESET_TIMER": sensing.visitResettimer,  # tested
-    "SENSING_DISTANCE_TO": sensing.visitDistanceto,  # tested
-    "SENSING_TO_DISTANCE_MENU": sensing.visitDistanceto_menu,  # tested
-    "SENSING_LOUDNESS": sensing.visitLoudness,  # tested
-    "SENSING_COLOR_TOUCHING_COLOR": sensing.visitColoristouchingcolor,  # tested
-    "SENSING_OF": sensing.visitOf,  # tested
-    "SENSING_CURRENT": sensing.visitCurrent,  # tested
-    "SENSING_ANSWER": sensing.visitAnswer,  # tested
-    "SENSING_DAYS_SINCE_2000": sensing.visitDayssince2000,  # tested
-    "SENSING_KEYPRESSED": sensing.visitKeypressed,  # tested
-    "SENSING_KEY_OPTIONS": sensing.visitKey_options,
-    "SENSING_MOUSEX": sensing.visitMousex,  # tested
-    "SENSING_MOUSE_DOWN": sensing.visitMousedown,  # tested
-    "SENSING_MOUSEY": sensing.visitMousey,  # tested
-    "SENSING_TIMER": sensing.visitTimer,  # tested
-    "SENSING_TOUCHING_COLOR": sensing.visitTouchingcolor,  # tested
-    "SENSING_TOUCHING_OBJECT": sensing.visitTouchingObject,  # tested
-    "SENSING_CURRENT_MENU": sensing.visitCurrent_menu,  # tested
-    "SENSING_TOUCHING_OBJECT_MENU": sensing.visitTouchingObjectMenu,  # tested
-    "SENSING_USERNAME": sensing.visitUsername,  # tested
-    "SENSING_OF_OBJECT_MENU": sensing.visitOf_object_menu,  # tested
+    opcodes.SENSING_ASK_AND_WAIT: sensing.visitAskandwait,  # tested
+    opcodes.SENSING_SET_DRAG_MODE: sensing.visitSetdragmode,  # tested
+    opcodes.SENSING_RESET_TIMER: sensing.visitResettimer,  # tested
+    opcodes.SENSING_DISTANCE_TO: sensing.visitDistanceto,  # tested
+    opcodes.SENSING_TO_DISTANCE_MENU: sensing.visitDistanceto_menu,  # tested
+    opcodes.SENSING_LOUDNESS: sensing.visitLoudness,  # tested
+    opcodes.SENSING_COLOR_TOUCHING_COLOR: sensing.visitColoristouchingcolor,  # tested
+    opcodes.SENSING_OF: sensing.visitOf,  # tested
+    opcodes.SENSING_CURRENT: sensing.visitCurrent,  # tested
+    opcodes.SENSING_ANSWER: sensing.visitAnswer,  # tested
+    opcodes.SENSING_DAYS_SINCE_2000: sensing.visitDayssince2000,  # tested
+    opcodes.SENSING_KEYPRESSED: sensing.visitKeypressed,  # tested
+    opcodes.SENSING_KEY_OPTIONS: sensing.visitKey_options,
+    opcodes.SENSING_MOUSEX: sensing.visitMousex,  # tested
+    opcodes.SENSING_MOUSE_DOWN: sensing.visitMousedown,  # tested
+    opcodes.SENSING_MOUSEY: sensing.visitMousey,  # tested
+    opcodes.SENSING_TIMER: sensing.visitTimer,  # tested
+    opcodes.SENSING_TOUCHING_COLOR: sensing.visitTouchingcolor,  # tested
+    opcodes.SENSING_TOUCHING_OBJECT: sensing.visitTouchingObject,  # tested
+    opcodes.SENSING_CURRENT_MENU: sensing.visitCurrent_menu,  # tested
+    opcodes.SENSING_TOUCHING_OBJECT_MENU: sensing.visitTouchingObjectMenu,  # tested
+    opcodes.SENSING_USERNAME: sensing.visitUsername,  # tested
+    opcodes.SENSING_OF_OBJECT_MENU: sensing.visitOf_object_menu,  # tested
 
     ### operator blocks ####
-    "OPERATOR_SUBSTRACT": operator.visitSubtract,  # tested
-    "OPERATOR_GREATER": operator.visitGt,  # tested
-    "OPERATOR_JOIN": operator.visitJoin,  # tested
-    "OPERATOR_LETTER_OF": operator.visitLetter_of,  # tested
-    "OPERATOR_LESS_THAN": operator.visitLt,  # tested
-    "OPERATOR_NOT": operator.visitNot,  # tested
-    "OPERATOR_MODULO": operator.visitMod,  # tested
-    "OPERATOR_ADD": operator.visitAdd,  # tested
-    "OPERATOR_EQUALS": operator.visitEquals,  # tested
-    "OPERATOR_MATH_OP": operator.visitMathop,  # tested
-    "OPERATOR_AND": operator.visitAnd,  # tested
-    "OPERATOR_ROUND": operator.visitRound,  # tested
-    "OPERATOR_MULTIPLY": operator.visitMultiply,  # tested
-    "OPERATOR_RANDOM": operator.visitRandom,  # tested
-    "OPERATOR_DIVIDE": operator.visitDivide,  # tested
-    "OPERATOR_CONTAINS": operator.visitContains,  # tested
-    "OPERATOR_OR": operator.visitOr,  # tested
-    "OPERATOR_LENGTH": operator.visitLength,  # tested
+    opcodes.OPERATOR_SUBSTRACT: operator.visitSubtract,  # tested
+    opcodes.OPERATOR_GREATER: operator.visitGt,  # tested
+    opcodes.OPERATOR_JOIN: operator.visitJoin,  # tested
+    opcodes.OPERATOR_LETTER_OF: operator.visitLetter_of,  # tested
+    opcodes.OPERATOR_LESS_THAN: operator.visitLt,  # tested
+    opcodes.OPERATOR_NOT: operator.visitNot,  # tested
+    opcodes.OPERATOR_MODULO: operator.visitMod,  # tested
+    opcodes.OPERATOR_ADD: operator.visitAdd,  # tested
+    opcodes.OPERATOR_EQUALS: operator.visitEquals,  # tested
+    opcodes.OPERATOR_MATH_OP: operator.visitMathop,  # tested
+    opcodes.OPERATOR_AND: operator.visitAnd,  # tested
+    opcodes.OPERATOR_ROUND: operator.visitRound,  # tested
+    opcodes.OPERATOR_MULTIPLY: operator.visitMultiply,  # tested
+    opcodes.OPERATOR_RANDOM: operator.visitRandom,  # tested
+    opcodes.OPERATOR_DIVIDE: operator.visitDivide,  # tested
+    opcodes.OPERATOR_CONTAINS: operator.visitContains,  # tested
+    opcodes.OPERATOR_OR: operator.visitOr,  # tested
+    opcodes.OPERATOR_LENGTH: operator.visitLength,  # tested
 
     ### data blocks ####
-    "DATA_ADD_TO_LIST": data.visitAddtolist,  # tested
-    "DATA_DELETE_OF_LIST": data.visitDeleteoflist,  # tested
-    "DATA_INSERT_AT_LIST": data.visitInsertatlist,  # tested
-    "DATA_REPLACE_ITEM_OF_LIST": data.visitReplaceitemoflist,  # tested
-    "DATA_ITEM_OF_LIST": data.visitItemoflist,  # tested
-    "DATA_ITEMNUM_OF_LIST": data.visitItemnumoflist,  # tested
-    "DATA_LENGTH_OF_LIST": data.visitLengthoflist,  # tested
-    "DATA_LIST_CONTAINS_ITEM": data.visitListcontainsitem,  # tested
-    "DATA_SHOW_LIST": data.visitShowlist,  # tested
-    "DATA_HIDE_LIST": data.visitHidelist,  # tested
-    "DATA_CONTENTS_OF_LIST": data.visitContentsoflist,  # tested
-    "DATA_SET_VARIABLE_TO": data.visitSetvariableto,  # tested
-    "DATA_CHANGE_VARIABLE_BY": data.visitChangevariableby,  # tested
-    "DATA_SHOW_VARIABLE": data.visitShowvariable,  # tested
-    "DATA_HIDE_VARIABLE": data.visitHidevariable,  # tested
+    opcodes.DATA_ADD_TO_LIST: data.visitAddtolist,  # tested
+    opcodes.DATA_DELETE_OF_LIST: data.visitDeleteoflist,  # tested
+    opcodes.DATA_INSERT_AT_LIST: data.visitInsertatlist,  # tested
+    opcodes.DATA_REPLACE_ITEM_OF_LIST: data.visitReplaceitemoflist,  # tested
+    opcodes.DATA_ITEM_OF_LIST: data.visitItemoflist,  # tested
+    opcodes.DATA_ITEMNUM_OF_LIST: data.visitItemnumoflist,  # tested
+    opcodes.DATA_LENGTH_OF_LIST: data.visitLengthoflist,  # tested
+    opcodes.DATA_LIST_CONTAINS_ITEM: data.visitListcontainsitem,  # tested
+    opcodes.DATA_SHOW_LIST: data.visitShowlist,  # tested
+    opcodes.DATA_HIDE_LIST: data.visitHidelist,  # tested
+    opcodes.DATA_CONTENTS_OF_LIST: data.visitContentsoflist,  # tested
+    opcodes.DATA_SET_VARIABLE_TO: data.visitSetvariableto,  # tested
+    opcodes.DATA_CHANGE_VARIABLE_BY: data.visitChangevariableby,  # tested
+    opcodes.DATA_SHOW_VARIABLE: data.visitShowvariable,  # tested
+    opcodes.DATA_HIDE_VARIABLE: data.visitHidevariable,  # tested
 
     # TODO: While writing tests I noticed, that the pen blocks changed a bit now,
     # TODO: check if the conversion of those blocks is still correct / necessary.
     #### pen blocks ####
-    "PEN_CLEAR": pen.visitClear,  # tested
-    "PEN_STAMP": pen.visitStamp,  # tested
-    "PEN_DOWN": pen.visitPenDown,  # tested
-    "PEN_UP": pen.visitPenUp,  # tested
-    "PEN_SET_COLOR": pen.visitSetPenColorToColor,  # tested
-    "PEN_CHANGE_COLOR": pen.visitChangePenColorParamBy,  # tested
-    "PEN_COLOR_PARAM_MENU": pen.visitPen_menu_colorParam,  # tested
-    "PEN_SET_PARAM": pen.visitSetPenColorParamTo,  # tested
-    "PEN_CHANGE_SIZE": pen.visitChangePenSizeBy,  # tested
-    "PEN_SET_SIZE": pen.visitSetPenSizeTo,  # tested
-    "PEN_SET_SHADE_TO_NUMBER": pen.visitSetPenShadeToNumber,  # tested
-    "PEN_CHANGE_PEN_SHADE_BY": pen.visitChangePenShadeByNumber,  # tested
-    "PEN_SET_PEN_HUE_TO_NUMBER": pen.visitSetPenHueToNumber,  # tested
+    opcodes.PEN_CLEAR: pen.visitClear,  # tested
+    opcodes.PEN_STAMP: pen.visitStamp,  # tested
+    opcodes.PEN_DOWN: pen.visitPenDown,  # tested
+    opcodes.PEN_UP: pen.visitPenUp,  # tested
+    opcodes.PEN_SET_COLOR: pen.visitSetPenColorToColor,  # tested
+    opcodes.PEN_CHANGE_COLOR: pen.visitChangePenColorParamBy,  # tested
+    opcodes.PEN_COLOR_PARAM_MENU: pen.visitPen_menu_colorParam,  # tested
+    opcodes.PEN_SET_PARAM: pen.visitSetPenColorParamTo,  # tested
+    opcodes.PEN_CHANGE_SIZE: pen.visitChangePenSizeBy,  # tested
+    opcodes.PEN_SET_SIZE: pen.visitSetPenSizeTo,  # tested
+    opcodes.PEN_SET_SHADE_TO_NUMBER: pen.visitSetPenShadeToNumber,  # tested
+    opcodes.PEN_CHANGE_PEN_SHADE_BY: pen.visitChangePenShadeByNumber,  # tested
+    opcodes.PEN_SET_PEN_HUE_TO_NUMBER: pen.visitSetPenHueToNumber,  # tested
 }

--- a/src/scratchtocatrobat/scratch/scratch3visitor/blockmapping.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/blockmapping.py
@@ -1,171 +1,170 @@
 import looks, motion, event, sensing, sound, operator, control, data, pen
+
 visitormap = {
     ### event blocks ####
-    "event_whenflagclicked" : event.visitWhenflagclicked, #tested
-    "event_broadcast" : event.visitBroadcast, #tested
-    "event_broadcastandwait" : event.visitBroadcastandwait, #tested
-    "event_whenkeypressed" : event.visitWhenkeypressed, #tested
-    "event_whenthisspriteclicked" : event.visitWhenthisspriteclicked, #tested
-    "event_whengreaterthan" : event.visitWhengreaterthan, #tested
-    "event_whenbackdropswitchesto" : event.visitWhenbackdropswitchesto, #tested
-    "event_whenbroadcastreceived" : event.visitWhenbroadcastreceived, #tested
+    "FLAG_CLICKED": event.visitWhenflagclicked,  # tested
+    "BROADCAST": event.visitBroadcast,  # tested
+    "BROADCAST_AND_WAIT": event.visitBroadcastandwait,  # tested
+    "KEY_PRESSED": event.visitWhenkeypressed,  # tested
+    "SPRITE_CLICKED": event.visitWhenthisspriteclicked,  # tested
+    "GREATER_THAN": event.visitWhengreaterthan,  # tested
+    "BACKDROP_SWITCHED_TO": event.visitWhenbackdropswitchesto,  # tested
+    "BROADCAST_RECEIVED": event.visitWhenbroadcastreceived,  # tested
 
     ### motion blocks ####
-    "motion_movesteps" : motion.visitMovesteps, #tested
-    "motion_turnright" : motion.visitTurnright, #tested
-    "motion_turnleft" : motion.visitTurnleft,#tested
-    "motion_goto" : motion.visitGoto,#tested
-    "motion_gotoxy" : motion.visitGotoxy,#tested
-    "motion_glideto" : motion.visitGlideto,#tested
-    "motion_glidesecstoxy" : motion.visitGlidesecstoxy,#tested
-    "motion_pointindirection" : motion.visitPointindirection,#tested
-    "motion_pointtowards" : motion.visitPointtowards,#tested
-    "motion_changexby" : motion.visitChangexby,#tested
-    "motion_setx" : motion.visitSetx,#tested
-    "motion_changeyby" : motion.visitChangeyby,#tested
-    "motion_sety" : motion.visitSety,#tested
-    "motion_ifonedgebounce" : motion.visitIfonedgebounce,#tested
-    "motion_setrotationstyle" : motion.visitSetrotationstyle,#tested
-    "motion_goto_menu" : motion.visitGoto_menu,#tested
-    "motion_glideto_menu" : motion.visitGlideto_menu,#tested
-    "motion_pointtowards_menu" : motion.visitPointtowards_menu,#tested
-    "motion_direction" : motion.visitDirection,#tested
-    "motion_yposition" : motion.visitYposition,#tested
-    "motion_xposition" : motion.visitXposition,#tested
+    "MOTION_MOVE_STEPS": motion.visitMovesteps,  # tested
+    "MOTION_TURN_RIGHT": motion.visitTurnright,  # tested
+    "MOTION_TURN_LEFT": motion.visitTurnleft,  # tested
+    "MOTION_GOTO": motion.visitGoto,  # tested
+    "MOTION_GOTO_XY": motion.visitGotoxy,  # tested
+    "MOTION_GLIDE_TO": motion.visitGlideto,  # tested
+    "MOTION_GLIDE_SECS_TO_XY": motion.visitGlidesecstoxy,  # tested
+    "MOTION_POINT_IN_DIR": motion.visitPointindirection,  # tested
+    "MOTION_POINT_TOWARDS": motion.visitPointtowards,  # tested
+    "MOTION_CHANGE_BY_XY": motion.visitChangexby,  # tested
+    "MOTION_SET_X": motion.visitSetx,  # tested
+    "MOTION_CHANGE_Y_BY": motion.visitChangeyby,  # tested
+    "MOTION_SET_Y": motion.visitSety,  # tested
+    "MOTION_BOUNCE_OFF_EDGE": motion.visitIfonedgebounce,  # tested
+    "MOTION_SET_ROTATIONSTYLE": motion.visitSetrotationstyle,  # tested
+    "MOTION_GOTO_MENU": motion.visitGoto_menu,  # tested
+    "MOTION_GLIDE_TO_MENU": motion.visitGlideto_menu,  # tested
+    "MOTION_POINT_TOWARDS_MENU": motion.visitPointtowards_menu,  # tested
+    "MOTION_DIR": motion.visitDirection,  # tested
+    "MOTION_Y_POS": motion.visitYposition,  # tested
+    "MOTION_X_POS": motion.visitXposition,  # tested
 
     ### look blocks ####
-    "looks_sayforsecs" : looks.visitSayforsecs,#tested
-    "looks_say" : looks.visitSay,#tested
-    "looks_thinkforsecs" : looks.visitThinkforsecs,#tested
-    "looks_think" : looks.visitThink,#tested
-    "looks_switchcostumeto" : looks.visitSwitchcostumeto,#tested
-    "looks_nextcostume" : looks.visitNextcostume,#tested
-    "looks_switchbackdropto" : looks.visitSwitchbackdropto,#tested
-    "looks_nextbackdrop" : looks.visitNextbackdrop,#tested
-    "looks_changesizeby" : looks.visitChangesizeby,#tested
-    "looks_setsizeto" : looks.visitSetsizeto,#tested
-    "looks_changeeffectby" : looks.visitChangeeffectby,#tested
-    "looks_seteffectto" : looks.visitSeteffectto,#tested
-    "looks_cleargraphiceffects" : looks.visitCleargraphiceffects,#tested
-    "looks_show" : looks.visitShow,#tested
-    "looks_hide" : looks.visitHide,#tested
-    "looks_gotofrontback" : looks.visitGotofrontback,#tested
-    "looks_goforwardbackwardlayers" : looks.visitGoforwardbackwardlayers, #tested by fleischhacker
-    "looks_costume" : looks.visitCostume, #tested
-    "looks_backdrops" : looks.visitBackdrops, #tested
-    "looks_costumenumbername" : looks.visitCostumenumbername, #tested
-    "looks_size" : looks.visitSize,#tested
-    "looks_backdropnumbername" : looks.visitBackdropnumbername,
+    "LOOKS_SAY_FOR_SECS": looks.visitSayforsecs,  # tested
+    "LOOKS_SAY": looks.visitSay,  # tested
+    "LOOKS_THINK_FOR_SECS": looks.visitThinkforsecs,  # tested
+    "LOOKS_THINK": looks.visitThink,  # tested
+    "LOOKS_SWITCH_COSTUME_TO": looks.visitSwitchcostumeto,  # tested
+    "LOOKS_NEXT_COSTUME": looks.visitNextcostume,  # tested
+    "LOOKS_SWITCH_BACKDROP_TO": looks.visitSwitchbackdropto,  # tested
+    "LOOKS_NEXT_BACKDROP": looks.visitNextbackdrop,  # tested
+    "LOOKS_CHANGE_SIZE_BY": looks.visitChangesizeby,  # tested
+    "LOOKS_SET_SIZE_TO": looks.visitSetsizeto,  # tested
+    "LOOKS_CHANGE_EFFECT_BY": looks.visitChangeeffectby,  # tested
+    "LOOKS_SET_EFFECT_TO": looks.visitSeteffectto,  # tested
+    "LOOKS_CLEAR_EFFECTS": looks.visitCleargraphiceffects,  # tested
+    "LOOKS_SHOW": looks.visitShow,  # tested
+    "LOOKS_HIDE": looks.visitHide,  # tested
+    "LOOKS_GOTO_FRONT_BACK": looks.visitGotofrontback,  # tested
+    "LOOKS_FORWARD_BACKWARD_LAYERS": looks.visitGoforwardbackwardlayers,  # tested by fleischhacker
+    "LOOKS_COSTUME": looks.visitCostume,  # tested
+    "LOOKS_BACKDROPS": looks.visitBackdrops,  # tested
+    "LOOKS_COSTUME_NUMBER_NAME": looks.visitCostumenumbername,  # tested
+    "LOOKS_SIZE": looks.visitSize,  # tested
+    "looks_backdropnumbername": looks.visitBackdropnumbername,
 
     ### sound blocks ####
-    "sound_play" : sound.visitPlay,#tested
-    "sound_playuntildone" : sound.visitPlayuntildone,#tested
-    "sound_stopallsounds" : sound.visitStopallsounds,#tested
-    "sound_changeeffectby" : sound.visitChangeeffectby, # TODO not implemented in catrobat yet
-    "sound_seteffectto" : sound.visitSeteffectto, # TODO not implemented in catrobat yet
-    "sound_cleareffects" : sound.visitCleareffects, # TODO not implemented in scratch2, workaroundq
-    "sound_changevolumeby" : sound.visitChangevolumeby,#tested
-    "sound_setvolumeto" : sound.visitSetvolumeto,#tested
-    "sound_sounds_menu" : sound.visitSounds_menu, #tested
-    "sound_volume" : sound.visitVolume,#tested
+    "SOUNDS_PLAY": sound.visitPlay,  # tested
+    "SOUNDS_PLAY_UNTIL_DONE": sound.visitPlayuntildone,  # tested
+    "SOUNDS_STOP_ALL": sound.visitStopallsounds,  # tested
+    "sound_changeeffectby": sound.visitChangeeffectby,  # TODO not implemented in catrobat yet
+    "sound_seteffectto": sound.visitSeteffectto,  # TODO not implemented in catrobat yet
+    "sound_cleareffects": sound.visitCleareffects,  # TODO not implemented in scratch2, workaroundq
+    "SOUNDS_CHANGE_VOLUME_BY": sound.visitChangevolumeby,  # tested
+    "SOUNDS_SET_VOLUME_TO": sound.visitSetvolumeto,  # tested
+    "SOUNDS_MENU": sound.visitSounds_menu,  # tested
+    "SOUNDS_VOLUME": sound.visitVolume,  # tested
 
     ### control blocks ####
-    "control_wait" : control.visitWait,#tested
-    "control_repeat" : control.visitRepeat,#tested
-    "control_if" : control.visitIf,#tested
-    "control_if_else" : control.visitIf_else,#tested
-    "control_wait_until" : control.visitWait_until,#tested
-    "control_repeat_until" : control.visitRepeat_until,#tested
-    "control_create_clone_of" : control.visitCreate_clone_of,#tested
-    "control_create_clone_of_menu" : control.visitCreate_clone_of_menu, #tested
-    "control_stop" : control.visitStop,#tested
-    "control_start_as_clone" : control.visitStart_as_clone,#tested
-    "control_forever" : control.visitForever,#tested
-    "control_delete_this_clone" : control.visitDelete_this_clone,#tested
-    "procedures_call" : control.visitProcedures_call, #tested
-    "procedures_definition" : control.visitProcedures_definition, #tested
-    "argument_reporter_string_number" : control.visitArgumentIntOrString, #tested
-    "argument_reporter_boolean" : control.visitArgumentBool, #tested
-    "procedures_prototype" : control.visitProcedures_prototype, #tested
+    "CONTROL_WAIT": control.visitWait,  # tested
+    "CONTROL_REPEAT": control.visitRepeat,  # tested
+    "CONTROL_IF": control.visitIf,  # tested
+    "CONTROL_IF_ELSE": control.visitIf_else,  # tested
+    "CONTROL_WAIT_UNTIL": control.visitWait_until,  # tested
+    "CONTROL_REPEAT_UNTIL": control.visitRepeat_until,  # tested
+    "CONTROL_CREATE_CLONE_OF": control.visitCreate_clone_of,  # tested
+    "CONTROL_CREATE_CLONE_OF_MENU": control.visitCreate_clone_of_menu,  # tested
+    "CONTROL_STOP": control.visitStop,  # tested
+    "CONTROL_START_AS_CLONE": control.visitStart_as_clone,  # tested
+    "CONTROL_FOREVER": control.visitForever,  # tested
+    "CONTROL_DELETE_THIS_CLONE": control.visitDelete_this_clone,  # tested
+    "CONTROL_PROCEDURES_CALL": control.visitProcedures_call,  # tested
+    "CONTROL_PROCEDURES_DEFINITION": control.visitProcedures_definition,  # tested
+    "CONTROL_ARGUMENT_REPORTER_STRING": control.visitArgumentIntOrString,  # tested
+    "CONTROL_ARGUMENT_REPORTER_BOOL": control.visitArgumentBool,  # tested
+    "CONTROL_PROCEDURES_PROTOTYPE": control.visitProcedures_prototype,  # tested
 
     ### sensing blocks ####
-    "sensing_askandwait" : sensing.visitAskandwait,#tested
-    "sensing_setdragmode" : sensing.visitSetdragmode,#tested
-    "sensing_resettimer" : sensing.visitResettimer,#tested
-    "sensing_distanceto" : sensing.visitDistanceto,#tested
-    "sensing_distancetomenu" : sensing.visitDistanceto_menu, #tested
-    "sensing_loudness" : sensing.visitLoudness,#tested
-    "sensing_coloristouchingcolor" : sensing.visitColoristouchingcolor,#tested
-    "sensing_of" : sensing.visitOf,#tested
-    "sensing_current" : sensing.visitCurrent,#tested
-    "sensing_answer" : sensing.visitAnswer,#tested
-    "sensing_dayssince2000" : sensing.visitDayssince2000,#tested
-    "sensing_keypressed" : sensing.visitKeypressed,#tested
-    "sensing_keyoptions" : sensing.visitKey_options,
-    "sensing_mousex" : sensing.visitMousex,#tested
-    "sensing_mousedown" : sensing.visitMousedown,#tested
-    "sensing_mousey" : sensing.visitMousey,#tested
-    "sensing_timer" : sensing.visitTimer,#tested
-    "sensing_touchingcolor" : sensing.visitTouchingcolor,#tested
-    "sensing_touchingobject" : sensing.visitTouchingObject,#tested
-    "sensing_currentmenu" : sensing.visitCurrent_menu, #tested
-    "sensing_touchingobjectmenu" : sensing.visitTouchingObjectMenu,#tested
-    "sensing_username" : sensing.visitUsername,#tested
-    "sensing_of_object_menu" : sensing.visitOf_object_menu, #tested
+    "SENSING_ASK_AND_WAIT": sensing.visitAskandwait,  # tested
+    "SENSING_SET_DRAG_MODE": sensing.visitSetdragmode,  # tested
+    "SENSING_RESET_TIMER": sensing.visitResettimer,  # tested
+    "SENSING_DISTANCE_TO": sensing.visitDistanceto,  # tested
+    "SENSING_TO_DISTANCE_MENU": sensing.visitDistanceto_menu,  # tested
+    "SENSING_LOUDNESS": sensing.visitLoudness,  # tested
+    "SENSING_COLOR_TOUCHING_COLOR": sensing.visitColoristouchingcolor,  # tested
+    "SENSING_OF": sensing.visitOf,  # tested
+    "SENSING_CURRENT": sensing.visitCurrent,  # tested
+    "SENSING_ANSWER": sensing.visitAnswer,  # tested
+    "SENSING_DAYS_SINCE_2000": sensing.visitDayssince2000,  # tested
+    "SENSING_KEYPRESSED": sensing.visitKeypressed,  # tested
+    "SENSING_KEY_OPTIONS": sensing.visitKey_options,
+    "SENSING_MOUSEX": sensing.visitMousex,  # tested
+    "SENSING_MOUSE_DOWN": sensing.visitMousedown,  # tested
+    "SENSING_MOUSEY": sensing.visitMousey,  # tested
+    "SENSING_TIMER": sensing.visitTimer,  # tested
+    "SENSING_TOUCHING_COLOR": sensing.visitTouchingcolor,  # tested
+    "SENSING_TOUCHING_OBJECT": sensing.visitTouchingObject,  # tested
+    "SENSING_CURRENT_MENU": sensing.visitCurrent_menu,  # tested
+    "SENSING_TOUCHING_OBJECT_MENU": sensing.visitTouchingObjectMenu,  # tested
+    "SENSING_USERNAME": sensing.visitUsername,  # tested
+    "SENSING_OF_OBJECT_MENU": sensing.visitOf_object_menu,  # tested
 
     ### operator blocks ####
-    "operator_subtract" : operator.visitSubtract,#tested
-    "operator_gt" : operator.visitGt,#tested
-    "operator_join" : operator.visitJoin,#tested
-    "operator_letter_of" : operator.visitLetter_of,#tested
-    "operator_lt" : operator.visitLt,#tested
-    "operator_not" : operator.visitNot,#tested
-    "operator_mod" : operator.visitMod,#tested
-    "operator_add" : operator.visitAdd,#tested
-    "operator_equals" : operator.visitEquals,#tested
-    "operator_mathop" : operator.visitMathop,#tested
-    "operator_and" : operator.visitAnd,#tested
-    "operator_round" : operator.visitRound,#tested
-    "operator_multiply" : operator.visitMultiply,#tested
-    "operator_random" : operator.visitRandom,#tested
-    "operator_divide" : operator.visitDivide,#tested
-    "operator_contains" : operator.visitContains,#tested
-    "operator_or" : operator.visitOr,#tested
-    "operator_length" : operator.visitLength,#tested
+    "OPERATOR_SUBSTRACT": operator.visitSubtract,  # tested
+    "OPERATOR_GREATER": operator.visitGt,  # tested
+    "OPERATOR_JOIN": operator.visitJoin,  # tested
+    "OPERATOR_LETTER_OF": operator.visitLetter_of,  # tested
+    "OPERATOR_LESS_THAN": operator.visitLt,  # tested
+    "OPERATOR_NOT": operator.visitNot,  # tested
+    "OPERATOR_MODULO": operator.visitMod,  # tested
+    "OPERATOR_ADD": operator.visitAdd,  # tested
+    "OPERATOR_EQUALS": operator.visitEquals,  # tested
+    "OPERATOR_MATH_OP": operator.visitMathop,  # tested
+    "OPERATOR_AND": operator.visitAnd,  # tested
+    "OPERATOR_ROUND": operator.visitRound,  # tested
+    "OPERATOR_MULTIPLY": operator.visitMultiply,  # tested
+    "OPERATOR_RANDOM": operator.visitRandom,  # tested
+    "OPERATOR_DIVIDE": operator.visitDivide,  # tested
+    "OPERATOR_CONTAINS": operator.visitContains,  # tested
+    "OPERATOR_OR": operator.visitOr,  # tested
+    "OPERATOR_LENGTH": operator.visitLength,  # tested
 
     ### data blocks ####
-    "data_addtolist" : data.visitAddtolist,#tested
-    "data_deleteoflist" : data.visitDeleteoflist,#tested
-    "data_insertatlist" : data.visitInsertatlist,#tested
-    "data_replaceitemoflist" : data.visitReplaceitemoflist,#tested
-    "data_itemoflist" : data.visitItemoflist,#tested
-    "data_itemnumoflist" : data.visitItemnumoflist,#tested
-    "data_lengthoflist" : data.visitLengthoflist,#tested
-    "data_listcontainsitem" : data.visitListcontainsitem,#tested
-    "data_showlist" : data.visitShowlist,#tested
-    "data_hidelist" : data.visitHidelist,#tested
-    "data_contentsoflist" : data.visitContentsoflist,#tested
-    "data_setvariableto" : data.visitSetvariableto,#tested
-    "data_changevariableby" : data.visitChangevariableby,#tested
-    "data_showvariable" : data.visitShowvariable,#tested
-    "data_hidevariable" : data.visitHidevariable,#tested
-
+    "DATA_ADD_TO_LIST": data.visitAddtolist,  # tested
+    "DATA_DELETE_OF_LIST": data.visitDeleteoflist,  # tested
+    "DATA_INSERT_AT_LIST": data.visitInsertatlist,  # tested
+    "DATA_REPLACE_ITEM_OF_LIST": data.visitReplaceitemoflist,  # tested
+    "DATA_ITEM_OF_LIST": data.visitItemoflist,  # tested
+    "DATA_ITEMNUM_OF_LIST": data.visitItemnumoflist,  # tested
+    "DATA_LENGTH_OF_LIST": data.visitLengthoflist,  # tested
+    "DATA_LIST_CONTAINS_ITEM": data.visitListcontainsitem,  # tested
+    "DATA_SHOW_LIST": data.visitShowlist,  # tested
+    "DATA_HIDE_LIST": data.visitHidelist,  # tested
+    "DATA_CONTENTS_OF_LIST": data.visitContentsoflist,  # tested
+    "DATA_SET_VARIABLE_TO": data.visitSetvariableto,  # tested
+    "DATA_CHANGE_VARIABLE_BY": data.visitChangevariableby,  # tested
+    "DATA_SHOW_VARIABLE": data.visitShowvariable,  # tested
+    "DATA_HIDE_VARIABLE": data.visitHidevariable,  # tested
 
     # TODO: While writing tests I noticed, that the pen blocks changed a bit now,
     # TODO: check if the conversion of those blocks is still correct / necessary.
     #### pen blocks ####
-    "pen_clear" : pen.visitClear,#tested
-    "pen_stamp" : pen.visitStamp,#tested
-    "pen_penDown" : pen.visitPenDown,#tested
-    "pen_penUp" : pen.visitPenUp,#tested
-    "pen_setPenColorToColor" : pen.visitSetPenColorToColor,#tested
-    "pen_changePenColorParamBy" : pen.visitChangePenColorParamBy,#tested
-    "pen_menu_colorParam" : pen.visitPen_menu_colorParam, #tested
-    "pen_setPenColorParamTo" : pen.visitSetPenColorParamTo, #tested
-    "pen_changePenSizeBy" : pen.visitChangePenSizeBy,#tested
-    "pen_setPenSizeTo" : pen.visitSetPenSizeTo,#tested
-    "pen_setPenShadeToNumber" : pen.visitSetPenShadeToNumber, #tested
-    "pen_changePenShadeBy" : pen.visitChangePenShadeByNumber, #tested
-    "pen_setPenHueToNumber" : pen.visitSetPenHueToNumber, #tested
+    "PEN_CLEAR": pen.visitClear,  # tested
+    "PEN_STAMP": pen.visitStamp,  # tested
+    "PEN_DOWN": pen.visitPenDown,  # tested
+    "PEN_UP": pen.visitPenUp,  # tested
+    "PEN_SET_COLOR": pen.visitSetPenColorToColor,  # tested
+    "PEN_CHANGE_COLOR": pen.visitChangePenColorParamBy,  # tested
+    "PEN_COLOR_PARAM_MENU": pen.visitPen_menu_colorParam,  # tested
+    "PEN_SET_PARAM": pen.visitSetPenColorParamTo,  # tested
+    "PEN_CHANGE_SIZE": pen.visitChangePenSizeBy,  # tested
+    "PEN_SET_SIZE": pen.visitSetPenSizeTo,  # tested
+    "PEN_SET_SHADE_TO_NUMBER": pen.visitSetPenShadeToNumber,  # tested
+    "PEN_CHANGE_PEN_SHADE_BY": pen.visitChangePenShadeByNumber,  # tested
+    "PEN_SET_PEN_HUE_TO_NUMBER": pen.visitSetPenHueToNumber,  # tested
 }
-

--- a/src/scratchtocatrobat/scratch/scratch3visitor/scratch2_json_format.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/scratch2_json_format.py
@@ -38,6 +38,7 @@ class Scratch3_2Opcodes(object):
     LOOKS_COSTUME = "looks_costume"
     LOOKS_BACKDROPS = "looks_backdrops"
     LOOKS_COSTUME_NUMBER_NAME = "looks_costumenumbername"
+    LOOKS_BACK_DROP_NUMBER_NAME = "looks_backdropnumbername"
 
     # sounds #
     SOUNDS_PLAY = "sound_play"

--- a/src/scratchtocatrobat/scratch/scratch3visitor/test_scratch3.py
+++ b/src/scratchtocatrobat/scratch/scratch3visitor/test_scratch3.py
@@ -260,7 +260,7 @@ def add_new_block_to_context(context, opcode):
 
 
 def create_dummy_formula_block(context):
-    operator = createScratch3Block(context, "operator_add")
+    operator = createScratch3Block(context, opcodes.OPERATOR_ADD)
     addInputOfType(operator, "NUM1", LiteralType.INT)
     addInputOfType(operator, "NUM2", LiteralType.INT)
     context.spriteblocks[operator.name] = operator
@@ -444,7 +444,7 @@ class TestScratch3Blocks(unittest.TestCase):
         testblock = context.block
         addInputOfType(testblock, "BACKDROP", LiteralType.STRING)
 
-        block2 = add_new_block_to_context(context, "looks_backdrops")
+        block2 = add_new_block_to_context(context, opcodes.LOOKS_BACKDROPS)
         block2.fields["BACKDROP"] = ["test_costume"]
         addInputToBlock(testblock, "BACKDROP", block2.name, InputType.BLOCK_NO_SHADOW)
         testblock.inputs["BACKDROP"] = [1, block2.name]
@@ -1475,7 +1475,7 @@ class TestScratch3Blocks(unittest.TestCase):
 
         ## test menu and motion_goto block combination
         context = create_block_context(opcodes.MOTION_GOTO)
-        add_menu_block(context, "motion_goto_menu", MenuTypes.TO, Types.TEST_MOTION)
+        add_menu_block(context, opcodes.MOTION_GOTO, MenuTypes.TO, Types.TEST_MOTION)
         converted_block = visitBlock(context)
         assert converted_block[0] == opcodes.opcode_map[opcodes.MOTION_GOTO]
         assert converted_block[1] == Types.TEST_MOTION

--- a/src/scratchtocatrobat/scratch/test_scratch.py
+++ b/src/scratchtocatrobat/scratch/test_scratch.py
@@ -323,2029 +323,2029 @@ class TestScriptFunc(unittest.TestCase):
         assert [block[0] for block in self.script.blocks] == expected_block_names
         assert self.script.raw_script == self.input_data[2]
 
-#
-# class TestBlockInit(unittest.TestCase):
-#
-#     def test_can_construct_on_correct_input(self):
-#         expected_values = (
-#             (4, (2, 2, 2, 1)),
-#             (1, (2,)),
-#             (1, (2,)),
-#         )
-#         for script_input, [expected_length, expected_block_children_number] in zip(EASY_SCRIPTS, expected_values):
-#             assert len(scratch.Script(script_input).blocks) == expected_length
-#             blocks = scratch.ScriptElement.from_raw_script(script_input)
-#             assert isinstance(blocks, scratch.BlockList) and len(blocks.children) == expected_length
-#             nested_blocks = blocks.children
-#             assert all(isinstance(block, scratch.ScriptElement) for block in nested_blocks)
-#             assert [len(block.children) for block in nested_blocks] == list(expected_block_children_number)
-#
-#
-# class TestScriptElementTree(common_testing.BaseTestCase):
-#
-#     def test_verify_simple_formula_in_script_element_tree(self):
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]]
-#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]
-#
-#         script = scratch.Script(script_data)
-#         assert script.type == scratch.SCRIPT_GREEN_FLAG
-#         assert len(script.arguments) == 0
-#         assert script.raw_script == expected_raw_script_data
-#         assert script.blocks == expected_raw_script_data[1:]
-#         assert isinstance(script.script_element, scratch.BlockList)
-#         assert script.script_element.name == '<LIST>'
-#         assert len(script.script_element.children) == 1
-#
-#         script_element_child = script.script_element.children[0]
-#         assert script_element_child.name == 'wait:elapsed:from:'
-#         assert len(script_element_child.children) == 1
-#
-#         script_element_child = script_element_child.children[0]
-#         assert script_element_child.name == 'randomFrom:to:'
-#         assert len(script_element_child.children) == 2
-#
-#         left_child = script_element_child.children[0]
-#         right_child = script_element_child.children[1]
-#         assert left_child.name == -100
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 100
-#         assert len(right_child.children) == 0
-#
-#     def test_verify_complex_formula_in_script_element_tree(self):
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-#                         0, ["randomFrom:to:", 0, 100]]]]]
-#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-#                         0, ["randomFrom:to:", 0, 100]]]]
-#
-#         script = scratch.Script(script_data)
-#         assert script.type == scratch.SCRIPT_GREEN_FLAG
-#         assert len(script.arguments) == 0
-#         assert script.raw_script == expected_raw_script_data
-#         assert script.blocks == expected_raw_script_data[1:]
-#         assert isinstance(script.script_element, scratch.BlockList)
-#         assert script.script_element.name == '<LIST>'
-#         assert len(script.script_element.children) == 1
-#
-#         script_element_child = script.script_element.children[0]
-#         assert script_element_child.name == 'wait:elapsed:from:'
-#         assert len(script_element_child.children) == 1
-#
-#         script_element_child = script_element_child.children[0]
-#         assert script_element_child.name == '+'
-#         assert len(script_element_child.children) == 2
-#
-#         left_child = script_element_child.children[0]
-#         right_child = script_element_child.children[1]
-#         assert left_child.name == 0
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 'randomFrom:to:'
-#         assert len(right_child.children) == 2
-#
-#         left_child = right_child.children[0]
-#         right_child = right_child.children[1]
-#         assert left_child.name == 0
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 100
-#         assert len(right_child.children) == 0
-#
-#     def test_verify_complex_script_element_tree(self):
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-#                         0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]]
-#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-#                         0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]
-#
-#         script = scratch.Script(script_data)
-#         assert script.type == scratch.SCRIPT_GREEN_FLAG
-#         assert len(script.arguments) == 0
-#         assert script.raw_script == expected_raw_script_data
-#         assert script.blocks == expected_raw_script_data[1:]
-#         assert isinstance(script.script_element, scratch.BlockList)
-#         assert script.script_element.name == '<LIST>'
-#         assert len(script.script_element.children) == 2
-#
-#         script_element_child = script.script_element.children[0]
-#         assert script_element_child.name == 'wait:elapsed:from:'
-#         assert len(script_element_child.children) == 1
-#         script_element_child = script_element_child.children[0]
-#         assert script_element_child.name == '+'
-#         assert len(script_element_child.children) == 2
-#
-#         left_child = script_element_child.children[0]
-#         right_child = script_element_child.children[1]
-#         assert left_child.name == 0
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 'randomFrom:to:'
-#         assert len(right_child.children) == 2
-#
-#         left_child = right_child.children[0]
-#         right_child = right_child.children[1]
-#         assert left_child.name == 0
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 100
-#         assert len(right_child.children) == 0
-#
-#         script_element_child = script.script_element.children[1]
-#         assert script_element_child.name == 'changeVar:by:'
-#         assert len(script_element_child.children) == 2
-#
-#         left_child = script_element_child.children[0]
-#         right_child = script_element_child.children[1]
-#         assert left_child.name == 'temp'
-#         assert len(left_child.children) == 0
-#         assert right_child.name == 0.1
-#         assert len(right_child.children) == 0
-#
-#
-# class TestTimerAndResetTimerBlockWorkarounds(unittest.TestCase):
-#     TIMER_HELPER_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [{ "objName": "Sprite1", "scripts": None }],
-#         "info": {}
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#
-#     def test_timer_block(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#         expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-#         ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 1
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_script_data)
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-#     def test_same_timer_block_twice(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["wait:elapsed:from:", ["timer"]]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-#         ]]
-#
-#         # create project
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 1
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_script_data)
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-#     def test_reset_timer_block_with_non_existant_timer_block_should_automatically_add_timer_script(self):
-#         cls = self.__class__
-#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]]
-#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-#         ]]]
-#         script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ['doBroadcastAndWait', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-#         ]]
-#
-#         # create project
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 2
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
-#         assert script == expected_script
-#         script = background_object.scripts[1]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-#     def test_reset_timer_block_with_existant_timer_block_in_same_object_must_NOT_be_ignored(self):
-#         cls = self.__class__
-#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]]
-#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-#         ]]]
-#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["timerReset"]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-#             ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-#         ]]
-#
-#         # create project
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 2
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
-#         assert script == expected_script
-#         script = background_object.scripts[1]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-#     def test_reset_timer_block_and_timer_block_within_loop_must_NOT_be_ignored(self):
-#         cls = self.__class__
-#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]]
-#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-#         ]]]
-#         script_data = [0, 0, [["whenGreenFlag"],
-#             ["doRepeat", 100, [["wait:elapsed:from:", ["timer"]], ["timerReset"]]]]
-#         ]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ["doRepeat", 100, [
-#                 ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-#                 ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]]
-#         ]]]
-#
-#         # create project
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 2
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
-#         assert script == expected_script
-#         script = background_object.scripts[1]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-#     def test_reset_timer_block_with_existant_timer_block_in_other_object_must_NOT_be_ignored(self):
-#         cls = self.__class__
-#         background_script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [background_script_data]
-#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-#             ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-#         ]], [0, 0, [['whenGreenFlag'],
-#             ['doForever', [
-#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]]
-#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-#         ]]]
-#
-#         # first object scripts
-#         first_object_script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
-#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [first_object_script_data]
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-#         ]]
-#
-#         # create project
-#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 3
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
-#         assert script == expected_script
-#         script = background_object.scripts[1]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
-#         assert script == expected_script
-#         script = background_object.scripts[2]
-#         expected_script = scratch.Script(expected_background_object_scripts_data[2])
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-#
-# class TestBackdropWorkaround(unittest.TestCase):
-#     BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [{'baseLayerMD5': ''}, {'baseLayerMD5': ''}, {'baseLayerMD5': ''}],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "scripts": [],
-#         "children": [{ "objName": "Sprite1", "scripts": [] }],
-#         "info": {}
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#
-#     def _setup_objects(self, blocks, backdrop_script = [], multiple_sprites = 1):
-#         cls = self.__class__
-#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = [{ "objName": "Sprite1", "scripts": [] }]
-#         input_script = [0, 0, [["whenGreenFlag"]]]
-#         expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
-#
-#         # parse backdrop input and output
-#         if backdrop_script:
-#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
-#             backdrop_script = [backdrop_script]
-#
-#         # validate backgrounds
-#         assert len(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["costumes"]) == 3
-#
-#         # initialize backdrop scripts
-#         for block in set(blocks):
-#             if "random" not in block:
-#                 backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", block]]])
-#             else:
-#                 backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", ['randomFrom:to:', 1.0, 3.0]]]])
-#
-#         # parse input and expected output
-#         for i in range(4):
-#             for block in blocks:
-#                 input_script[2].extend([["startScene", block],["wait:elapsed:from:", 1]])
-#                 expected_sprite_script[2].extend([["broadcast:", block], ["wait:elapsed:from:", 1]])
-#
-#         # multiple sprites?
-#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [input_script]
-#         if multiple_sprites == 2:
-#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": []})
-#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [input_script]
-#
-#         # prepare values for return
-#         expected_sprite_script = scratch.Script(expected_sprite_script)
-#         expected_backdrop = []
-#         for script in backdrop_script:
-#             expected_backdrop.append(scratch.Script(script))
-#         raw_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
-#         return {"converted": raw_project, "expected": {"Backdrop": expected_backdrop, "Sprite": [expected_sprite_script]}}
-#
-#     def test_previous_backdrop_in_single_sprite(self):
-#         test_data = self._setup_objects(["previous backdrop"], [])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_multiple_sprites(self):
-#         test_data = self._setup_objects(["previous backdrop"], [], 2)
-#
-#         assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
-#         assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#         assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#         assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_multiple_backdrop_scripts_single_sprite(self):
-#         test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_multiple_backdrop_scripts_multiple_sprites(self):
-#         test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
-#
-#         assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
-#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#         assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#         assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_random_backdrop_in_stage(self):
-#         cls = self.__class__
-#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
-#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [[0,0,[['whenGreenFlag'], ['startScene', 'random backdrop']]]]
-#         expected = scratch.Script([0,0,[['whenGreenFlag'], ['startScene', ['randomFrom:to:', 1.0, 3.0]]]])
-#         converted_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
-#
-#         assert len(converted_project.objects) == 1
-#         assert len(converted_project.objects[0].scripts) == 1
-#
-#         assert converted_project.objects[0].scripts[0] == expected
-#
-#     def test_next_backdrop_and_previous_backdrop_in_single_sprite(self):
-#         test_data = self._setup_objects(["next backdrop", "previous backdrop"], [])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_next_backdrop_and_random_backdrop_in_single_sprite(self):
-#         test_data = self._setup_objects(["next backdrop", "random backdrop"], [])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_and_random_backdrop_in_single_sprite(self):
-#         test_data = self._setup_objects(["previous backdrop", "random backdrop"], [])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_next_backdrop_and_random_backdrop_in_single_sprite(self):
-#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"], [])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 3 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_single_sprite(self):
-#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
-#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-#     def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_multiple_sprites(self):
-#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
-#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
-#
-#         assert len(test_data["converted"].objects) == 3
-#         assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
-#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-#
-#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-#
-# class TestKeyPressedWorkaround(unittest.TestCase):
-#     KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [{ "objName": "Sprite1", "scripts": None }],
-#         "info": {}
-#     }
-#
-#     KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE = {
-#         "doIf": [['doIf', ['keyPressed:', None], None]],
-#         "doIfElse": [['doIfElse', ['keyPressed:', None], None, None]],
-#         "doUntil": [['doUntil', ['keyPressed:', None], None]],
-#         "doWaitUntil": [['doWaitUntil', ['keyPressed:', None]]]
-#     }
-#
-#     KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS = {
-#         "or": [['|', ['keyPressed:', None], ['keyPressed:', None]]],
-#         "and": [['&', ['keyPressed:', None], ['keyPressed:', None]]],
-#         "not": ['not', ['keyPressed:', None]]
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
-#
-#     def _setup_objects(self, blocks, keys, backdrop_script = [], multiple_sprites = 1, operator = None):
-#         cls = self.__class__
-#         input_script = [0, 0, [["whenGreenFlag"]]]
-#         expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
-#
-#         if operator is not None:
-#             assert len(keys) > 1
-#
-#         if backdrop_script:
-#             cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
-#
-#         for block in set(blocks):
-#             input_script[2].extend(cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block])
-#             script_after = cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block]
-#             script_after[0][1][0] = "readVariable"
-#             script_after[0][1][1] = "S2CC:key_" + str(keys[0])
-#             expected_sprite_script[2].extend(script_after)
-#
-#         if len(set(blocks)) > 1 and (operator == "or" or operator == "and"):
-#             operator_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS.get(operator)
-#             operator_brick[0][1][1] = str(keys[0])
-#             operator_brick[0][2][1] = str(keys[1])
-#             input_script[2].extend(operator_brick)
-#             for x in [1,2]:
-#                 for y in [0,1]:
-#                     operator_brick[0][x][y] = ("S2CC:key_" + str(keys[x-1])
-#                                                if operator_brick[0][x][y] in keys
-#                                                else "readVariable")
-#             expected_sprite_script[2].extend(operator_brick)
-#         elif operator == "not":
-#             not_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS["not"]
-#             not_brick[1][1] = keys[0]
-#             input_script[2].extend(not_brick)
-#             not_brick[1][0] = "readVariable"
-#             not_brick[1][1] = "S2CC:key_" + str(keys[0])
-#             expected_sprite_script[2].extend(not_brick)
-#
-#         for index in range(multiple_sprites):
-#             cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite" + str(index+1), "scripts": [input_script]})
-#
-#         expected_sprite_script = scratch.Script(expected_sprite_script)
-#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-#         return {"converted": raw_project, "expected_sprite": [expected_sprite_script]}
-#
-#     def test_key_pressed_do_if_block_up_arrow_key(self):
-#         test_data = self._setup_objects(["doIf"], ["up arrow"])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_if_else_block_space_key(self):
-#         test_data = self._setup_objects(["doIfElse"], ["space"])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_until_block_down_arrow_key(self):
-#         test_data = self._setup_objects(["doUntil"], ["down arrow"])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_wait_until_block_any_key(self):
-#         test_data = self._setup_objects(["doWaitUntil"], ["any"])
-#
-#         assert len(test_data["converted"].objects) == 2
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_if_and_do_if_else_blocks_i_key_multiple_sprites(self):
-#         test_data = self._setup_objects(["doIf", "doIfElse"], ["i"], [], 3)
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_until_and_do_wait_until_blocks_n_key_multiple_sprites(self):
-#         test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space"], [], 3)
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_wait_until_block_any_key_backdrop_script_multiple_sprites(self):
-#         test_data = self._setup_objects(["doWaitUntil"], ["any"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3)
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 1
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_until_and_do_wait_until_blocks_space_and_i_keys_multiple_sprites_and_and_block(self):
-#         test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space", "i"], [], 3, "and")
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_if_and_do_if_else_blocks_any_and_up_arrow_keys_multiple_sprites_and_or_block(self):
-#         test_data = self._setup_objects(["doIf", "doIfElse"], ["any", "up arrow"], [], 3, "or")
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 0
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed_do_until_do_wait_until_do_if_and_do_if_else_blocks_right_arrow_and_y_keys_backdrop_script_multiple_sprites_and_not_block(self):
-#         test_data = self._setup_objects(["doUntil", "doWaitUntil", "doIf", "doIfElse"], ["right arrow", "y"],
-#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3, "not")
-#
-#         assert len(test_data["converted"].objects) == 4
-#         assert len(test_data["converted"].objects[0].scripts) == 1
-#         assert len(test_data["converted"].objects[1].scripts) == 1
-#
-#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-#
-#     def test_key_pressed(self):
-#         cls = self.__class__
-#         script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["keyPressed:", "w"],[["changeYposBy:", 1]]]]]]]
-#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
-#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-#         key_pressed_var_name = scratch.S2CC_KEY_VARIABLE_NAME + "w"
-#         expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["readVariable", key_pressed_var_name],[["changeYposBy:", 1]]]]]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, sprite_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         script = sprite_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#     def test_key_pressed_with_formula(self):
-#         cls = self.__class__
-#         script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", [u'keyPressed:', [u'+', 3.0, 2.0]],[["changeYposBy:", 1]]]]]]]
-#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
-#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-#         expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever",
-#                                                                     [["doIf", ["=", "space", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_space"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "up arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_up arrow"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "down arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_down arrow"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "left arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_left arrow"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "right arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_right arrow"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "1", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_1"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "2", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_2"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "3", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_3"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "4", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_4"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "5", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_5"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "6", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_6"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "7", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_7"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "8", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_8"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "9", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_9"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "0", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_0"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "q", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_q"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "w", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_w"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "e", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_e"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "r", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_r"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "t", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_t"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "z", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_z"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "u", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_u"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "i", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_i"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "o", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_o"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "p", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_p"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "a", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_a"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "s", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_s"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "d", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_d"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "f", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_f"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "g", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_g"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "h", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_h"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "j", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_j"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "k", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_k"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "l", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_l"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "y", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_y"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "x", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_x"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "c", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_c"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "v", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_v"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "b", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_b"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "n", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_n"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "m", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_m"], [["changeYposBy:", 1]]]]],
-#                                                                      ["doIf", ["=", "any", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_any"], [["changeYposBy:", 1]]]]]]]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, sprite_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         script = sprite_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-# class TestDistanceBlockWorkaround(unittest.TestCase):
-#     DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [{ "objName": "Sprite1", "scripts": None },
-#                      { "objName": "Sprite2", "scripts": None }],
-#         "info": {}
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#
-#     def test_single_distance_block(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-#               ]
-#             ]]
-#         ]]]
-#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ["doForever", [
-#               ["setVar:to:", position_x_var_name, ["xpos"]],
-#               ["setVar:to:", position_y_var_name, ["ypos"]],
-#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 1
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 2
-#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-#
-#     def test_two_distance_blocks_in_same_object(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]],
-#                               ["forward:", ["distanceTo:", "Sprite2"]]]]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-#               ]
-#             ]]
-#         ], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-#               ]
-#             ]]
-#         ]]]
-#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ["doForever", [
-#               ["setVar:to:", position_x_var_name, ["xpos"]],
-#               ["setVar:to:", position_y_var_name, ["ypos"]],
-#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 1
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 2
-#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-#
-#     def test_two_distance_blocks_in_different_objects(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-#         expected_background_and_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-#               ]
-#             ]]
-#         ]]]
-#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ["doForever", [
-#               ["setVar:to:", position_x_var_name, ["xpos"]],
-#               ["setVar:to:", position_y_var_name, ["ypos"]],
-#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 1
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_and_first_object_script_data)
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_and_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 1
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 2
-#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-#
-#     def test_two_different_distance_blocks_in_different_objects(self):
-#         cls = self.__class__
-#         script_data0 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-#         script_data2 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite1"]]]]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data0]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = []
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [script_data2]
-#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-#         position_x_var_name1 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite1"
-#         position_y_var_name1 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite1"
-#         position_x_var_name2 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-#         position_y_var_name2 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-#         expected_background_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]]
-#               ]
-#             ]]
-#         ]]]
-#         expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-#             ["doForever", [
-#               ["setVar:to:", position_x_var_name1, ["xpos"]],
-#               ["setVar:to:", position_y_var_name1, ["ypos"]],
-#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]
-#         expected_second_object_scripts_data = [[0, 0, [["whenGreenFlag"], ['forward:',
-#             ["computeFunction:of:", "sqrt", ["+",
-#               ["*",
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]],
-#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]]
-#               ], ["*",
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]],
-#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]]
-#               ]
-#             ]]
-#         ]]], [0, 0, [['whenGreenFlag'],
-#             ["doForever", [
-#               ["setVar:to:", position_x_var_name2, ["xpos"]],
-#               ["setVar:to:", position_y_var_name2, ["ypos"]],
-#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#             ]]
-#         ]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 1
-#         script = background_object.scripts[0]
-#         expected_script = scratch.Script(expected_background_object_script_data)
-#         assert script == expected_script
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 2
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_scripts_data[0])
-#         assert script == expected_script
-#         script = second_object.scripts[1]
-#         expected_script = scratch.Script(expected_second_object_scripts_data[1])
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 4
-#         assert global_variables[0] == { "name": position_x_var_name2, "value": 0, "isPersistent": False }
-#         assert global_variables[1] == { "name": position_y_var_name2, "value": 0, "isPersistent": False }
-#         assert global_variables[2] == { "name": position_x_var_name1, "value": 0, "isPersistent": False }
-#         assert global_variables[3] == { "name": position_y_var_name1, "value": 0, "isPersistent": False }
-#
-#     def test_single_distance_block_to_mouse_pointer(self):
-#         cls = self.__class__
-#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "_mouse_"]]]]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "_mouse_"
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "_mouse_"
-#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ["forward:",
-#             ["computeFunction:of:", "sqrt",
-#                 ["+",
-#                     ["*",
-#                         ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-#                         ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-#                     ],
-#                     ["*",
-#                         ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-#                         ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-#                     ]
-#                  ]]
-#             ]]]
-#
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # mouse-sprite will be created during conversion and not in the pre-processing ->
-#         # for now, the second sprite is irrelevant
-#         assert len(second_object.scripts) == 0
-#
-#         # global variables; for the mouse-pointer workaround, the variables are created during conversion
-#         # and not in the pre-process
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 0
-#
-#         # check the flag -> indicates that mouse-sprite has to be created during conversion
-#         assert raw_project._has_mouse_position_script
-#
-# class TestGlideToObjectBlockWorkaround(unittest.TestCase):
-#     GLIDE_TO_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [{ "objName": "Sprite1", "scripts": None },
-#                      { "objName": "Sprite2", "scripts": None }],
-#         "info": {}
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#
-#     def test_glide_to_different_sprite(self):
-#         cls = self.__class__
-#         spinner_selection = "Sprite2"
-#         time_in_sec = "1"
-#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-#
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
-#         expected_first_object_script_data = \
-#             [0, 0, [["whenGreenFlag"], [
-#                 "glideSecs:toX:y:elapsed:from:",
-#                  time_in_sec,
-#                 ["readVariable", position_x_var_name],
-#                 ["readVariable", position_y_var_name]
-#             ]]]
-#
-#         expected_second_object_script_data = \
-#             [0, 0, [["whenGreenFlag"],[
-#                     "doForever", [
-#                         ["setVar:to:", position_x_var_name, ["xpos"]],
-#                         ["setVar:to:", position_y_var_name, ["ypos"]],
-#                         ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                  ]]
-#             ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 1
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_script_data)
-#         assert script == expected_script
-#
-#         # global variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 2
-#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-#
-#     def test_glide_to_random_position(self):
-#         cls = self.__class__
-#         spinner_selection = "_random_"
-#         time_in_sec = "1"
-#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-#
-#         # random position also needs a workaround -> different resolutions in scratch and pocket code
-#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-#
-#         expected_first_object_script_data = \
-#             [0, 0, [["whenGreenFlag"],[
-#                 "glideSecs:toX:y:elapsed:from:",
-#                 time_in_sec,
-#                 ["randomFrom:to:", left_x, right_x],
-#                 ["randomFrom:to:", lower_y, upper_y]
-#             ]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 0
-#
-#     def test_glide_to_mouse_poointer(self):
-#         cls = self.__class__
-#         spinner_selection = "_mouse_"
-#         time_in_sec = "1"
-#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-#
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
-#         expected_first_object_script_data = \
-#             [0, 0, [["whenGreenFlag"], [
-#                 "glideSecs:toX:y:elapsed:from:",
-#                 time_in_sec,
-#                 ["readVariable", position_x_var_name],
-#                 ["readVariable", position_y_var_name]
-#             ]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # same as in the 'distanceTo'-block workaround, the mouse-sprite is created during
-#         # conversion and not in the pre-processing -> no mouse-sprite yet
-#         assert len(second_object.scripts) == 0
-#
-#         # global variables; for the mouse-pointer workaround, the variables are created during conversion
-#         # and not in the pre-process
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 0
-#
-#         # check the flag -> indicates that mouse-sprite has to be created during conversion
-#         assert raw_project._has_mouse_position_script
-#
-#     def test_glide_to_random_single_nested(self):
-#         cls = self.__class__
-#         spinner_selection = "_random_"
-#         time_in_sec = "1"
-#         script_data = [0, 0, [["whenGreenFlag"], ["doForever", ["glideTo:", time_in_sec, spinner_selection]]]]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-#
-#         # random position also needs a workaround -> different resolutions in scratch and pocket code
-#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-#
-#         expected_first_object_script_data = \
-#             [0, 0, [["whenGreenFlag"],
-#                 ["doForever",
-#                     ["glideSecs:toX:y:elapsed:from:",
-#                         time_in_sec,
-#                         ["randomFrom:to:", left_x, right_x],
-#                         ["randomFrom:to:", lower_y, upper_y]
-#                     ]
-#                 ]
-#             ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 0
-#
-#     def test_glide_to_objects_double_nested(self):
-#         cls = self.__class__
-#         spinner_selection_random = "_random_"
-#         spinner_selection_mouse = "_mouse_"
-#         time_in_sec = "1"
-#
-#         script_data = [0, 0, [["whenGreenFlag"],
-#                                 ["doForever",
-#                                     ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
-#                                         ["glideTo:", time_in_sec, spinner_selection_random],
-#                                         ["glideTo:", time_in_sec, spinner_selection_mouse]
-#                                     ]
-#                                 ]
-#                             ]]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-#
-#         # variables for x and y positions of the mouse-pointer
-#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection_mouse
-#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection_mouse
-#
-#         # random position option also needs a workaround -> different resolutions in scratch and pocket code
-#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-#
-#         expected_first_object_script_data = \
-#             [0, 0, [["whenGreenFlag"],
-#                     ["doForever",
-#                         ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
-#                             ["glideSecs:toX:y:elapsed:from:",
-#                                 time_in_sec,
-#                                 ["randomFrom:to:", left_x, right_x],
-#                                 ["randomFrom:to:", lower_y, upper_y]
-#                             ],
-#                             ["glideSecs:toX:y:elapsed:from:",
-#                                 time_in_sec,
-#                                 ["readVariable", position_x_var_name],
-#                                 ["readVariable", position_y_var_name]
-#                             ]
-#                         ]
-#                     ]
-#             ]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # background object
-#         assert len(background_object.scripts) == 0
-#
-#         # first object
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_script_data)
-#         assert script == expected_script
-#
-#         # second object
-#         assert len(second_object.scripts) == 0
-#
-#
-# class TestShowSensorBlockWorkarounds(unittest.TestCase):
-#     SENSOR_HELPER_OBJECTS_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [{ "objName": "Sprite1", "scripts": [] }],
-#         "info": {}
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-#         self.original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"][:]
-#
-#     def tearDown(self):
-#         unittest.TestCase.tearDown(self)
-#         cls = self.__class__
-#         cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = self.original_child_objects[:]
-#
-#     def test_convert_show_sensor_without_parameter_block(self):
-#         cls = self.__class__
-#         sprite_name = "Sprite1"
-#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-#         for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-#                 "target": sprite_name,
-#                 "cmd": command_name,
-#                 "param": None,
-#                 "visible": True
-#             }]
-#
-#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
-#             expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [command_name]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 0
-#             assert len(first_object.scripts) == 1
-#             script = first_object.scripts[0]
-#             expected_script = scratch.Script(expected_first_object_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(background_object._dict_object["variables"]) == 0
-#             first_object_variables = first_object._dict_object["variables"]
-#             assert len(first_object_variables) == 1
-#             assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_show_sensor_with_parameter_block(self):
-#         cls = self.__class__
-#         sprite_name = "Sprite1"
-#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-#         for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-#                 "target": sprite_name,
-#                 "cmd": command_name,
-#                 "param": param,
-#                 "visible": True
-#             }]
-#
-#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
-#             expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [command_name, param]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 0
-#             assert len(first_object.scripts) == 1
-#             script = first_object.scripts[0]
-#             expected_script = scratch.Script(expected_first_object_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(background_object._dict_object["variables"]) == 0
-#             first_object_variables = first_object._dict_object["variables"]
-#             assert len(first_object_variables) == 1
-#             assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_stage_specific_show_sensor_without_parameter_block(self):
-#         cls = self.__class__
-#         sprite_name = "Stage"
-#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-#         for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-#                 "target": sprite_name,
-#                 "cmd": command_name,
-#                 "param": None,
-#                 "visible": True
-#             }]
-#
-#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
-#             expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [command_name]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(first_object.scripts) == 0
-#             assert len(background_object.scripts) == 1
-#             script = background_object.scripts[0]
-#             expected_script = scratch.Script(expected_stage_object_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(first_object._dict_object["variables"]) == 0
-#             stage_object_variables = background_object._dict_object["variables"]
-#             assert len(stage_object_variables) == 1
-#             assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_stage_specific_show_sensor_with_parameter_block(self):
-#         cls = self.__class__
-#         sprite_name = "Stage"
-#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-#         for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-#                 "target": sprite_name,
-#                 "cmd": command_name,
-#                 "param": param,
-#                 "visible": True
-#             }]
-#
-#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
-#             expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [command_name, param]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(first_object.scripts) == 0
-#             assert len(background_object.scripts) == 1
-#             script = background_object.scripts[0]
-#             expected_script = scratch.Script(expected_stage_object_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(first_object._dict_object["variables"]) == 0
-#             stage_object_variables = background_object._dict_object["variables"]
-#             assert len(stage_object_variables) == 1
-#             assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#
-# class TestGetAttributeBlockWorkarounds(unittest.TestCase):
-#
-#     ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP = {
-#         "x position": "xpos",
-#         "y position": "ypos",
-#         "direction": "heading",
-#         "costume #": "costumeIndex",
-#         "costume name": "costumeName",
-#         "size": "scale",
-#         "volume": "volume"
-#     }
-#
-#     def setUp(self):
-#         unittest.TestCase.setUp(self)
-#         cls = self.__class__
-#         self.root_info = {
-#             "objName": "Stage",
-#             "sounds": [],
-#             "costumes": [],
-#             "currentCostumeIndex": 0,
-#             "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#             "penLayerID": 0,
-#             "tempoBPM": 60,
-#             "videoAlpha": 0.5,
-#             "children": [{ "objName": "Sprite1", "scripts": [] }],
-#             "scripts": [],
-#             "variables": [{ "name": "result", "value": 1, "isPersistent": False }],
-#             "info": {}
-#         }
-#
-#     def test_convert_global_variable_attribute_block(self):
-#         cls = self.__class__
-#         variable_name = "result"
-#         first_script_data = [0, 0, [["whenGreenFlag"],
-#             ["wait:elapsed:from:", 2],
-#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, "_stage_"]]
-#         ]]
-#         self.root_info["children"][0]["scripts"] = [first_script_data]
-#         raw_project = scratch.RawProject(self.root_info)
-#         first_script_data[2][2][2] = ["readVariable", variable_name]
-#         expected_first_object_first_script_data = first_script_data
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # scripts of sprite objects
-#         assert len(background_object.scripts) == 0
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_first_script_data)
-#         assert script == expected_script
-#
-#         # sprite variables
-#         global_variables = background_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert len(first_object._dict_object["variables"]) == 0
-#         assert global_variables[0] == { "name": variable_name, "value": 1, "isPersistent": False }
-#
-#     def test_convert_local_variable_of_same_object_attribute_block(self):
-#         cls = self.__class__
-#         sprite_name = "Sprite1"
-#         variable_name = "localVariable"
-#         first_script_data = [0, 0, [["whenGreenFlag"],
-#             ["wait:elapsed:from:", 2],
-#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name]]
-#         ]]
-#         self.root_info["children"][0]["scripts"] = [first_script_data]
-#         self.root_info["children"][0]["variables"] = [{ "name": variable_name, "value": 0, "isPersistent": False }]
-#         raw_project = scratch.RawProject(self.root_info)
-#         first_script_data[2][2][2] = ["readVariable", variable_name]
-#         expected_first_object_first_script_data = first_script_data
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # scripts of sprite objects
-#         assert len(background_object.scripts) == 0
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_first_script_data)
-#         assert script == expected_script
-#
-#         # sprite variables
-#         global_variables = background_object._dict_object["variables"]
-#         first_object_variables = first_object._dict_object["variables"]
-#         assert len(global_variables) == 1
-#         assert len(first_object_variables) == 1
-#         assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-#         assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_local_variable_of_other_object_attribute_block(self):
-#         cls = self.__class__
-#         sprite_name_of_other_object = "Sprite2"
-#         variable_name = "localVariableOfSprite2"
-#         self.root_info["children"] += [{
-#             "objName": sprite_name_of_other_object,
-#             "scripts": [],
-#             "variables": [{ "name": variable_name, "value": 0, "isPersistent": False }]
-#         }]
-#         first_script_data = [0, 0, [["whenGreenFlag"],
-#             ["wait:elapsed:from:", 2],
-#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name_of_other_object]]
-#         ]]
-#         self.root_info["children"][0]["scripts"] = [first_script_data]
-#         raw_project = scratch.RawProject(self.root_info)
-#         helper_variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_readVariable:{}".format(sprite_name_of_other_object, variable_name)
-#         first_script_data[2][2][2] = ["readVariable", helper_variable_name]
-#         expected_first_object_first_script_data = first_script_data
-#         expected_second_object_first_script_data = [0, 0, [["whenGreenFlag"], ["doForever", [
-#             ["setVar:to:", helper_variable_name, ["readVariable", variable_name]],
-#             ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#         ]]]]
-#
-#         # validate
-#         assert len(raw_project.objects) == 3
-#         [background_object, first_object, second_object] = raw_project.objects
-#
-#         # scripts of sprite objects
-#         assert len(background_object.scripts) == 0
-#         assert len(first_object.scripts) == 1
-#         assert len(second_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_first_script_data)
-#         assert script == expected_script
-#         script = second_object.scripts[0]
-#         expected_script = scratch.Script(expected_second_object_first_script_data)
-#         assert script == expected_script
-#
-#         # sprite variables
-#         global_variables = background_object._dict_object["variables"]
-#         second_object_variables = second_object._dict_object["variables"]
-#         assert len(global_variables) == 2
-#         assert len(first_object._dict_object["variables"]) == 0
-#         assert len(second_object_variables) == 1
-#         assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-#         assert global_variables[1] == { "name": helper_variable_name, "value": 0, "isPersistent": False }
-#         assert second_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_background_specific_attributes_of_same_object_block(self):
-#         cls = self.__class__
-#         stage_name = "Stage"
-#         for attribute_name, sensor_name in [("backdrop #", "backgroundIndex"), ("backdrop name", "sceneName")]:
-#             first_script_data = [0, 0, [["whenGreenFlag"],
-#                 ["wait:elapsed:from:", 2],
-#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, stage_name]]
-#             ]]
-#             self.root_info["scripts"] = [first_script_data]
-#             raw_project = scratch.RawProject(self.root_info)
-#             first_script_data[2][2][2] = [sensor_name]
-#             expected_stage_object_first_script_data = first_script_data
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 1
-#             assert len(first_object.scripts) == 0
-#             script = background_object.scripts[0]
-#             expected_script = scratch.Script(expected_stage_object_first_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(background_object._dict_object["variables"]) == 1
-#             assert len(first_object._dict_object["variables"]) == 0
-#
-#     def test_convert_attribute_of_same_object_block(self):
-#         cls = self.__class__
-#         sprite_name = "Sprite1"
-#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-#             first_script_data = [0, 0, [["whenGreenFlag"],
-#                 ["wait:elapsed:from:", 2],
-#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, sprite_name]]
-#             ]]
-#             self.root_info["children"][0]["scripts"] = [first_script_data]
-#             raw_project = scratch.RawProject(self.root_info)
-#             first_script_data[2][2][2] = [sensor_name]
-#             expected_first_object_first_script_data = first_script_data
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 0
-#             assert len(first_object.scripts) == 1
-#             script = first_object.scripts[0]
-#             expected_script = scratch.Script(expected_first_object_first_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             assert len(background_object._dict_object["variables"]) == 1
-#             assert len(first_object._dict_object["variables"]) == 0
-#
-#     def test_should_convert_attribute_with_formula_block_to_zero_placeholder(self):
-#         cls = self.__class__
-#         first_script_data = [0, 0, [["whenGreenFlag"],
-#             ["wait:elapsed:from:", 2],
-#             ["setVar:to:", "result", ["getAttribute:of:", "x position", ["+", 1, 2]]]
-#         ]]
-#         self.root_info["children"][0]["scripts"] = [first_script_data]
-#         raw_project = scratch.RawProject(self.root_info)
-#         first_script_data[2][2][2] = 0
-#         expected_first_object_first_script_data = first_script_data
-#
-#         # validate
-#         assert len(raw_project.objects) == 2
-#         [background_object, first_object] = raw_project.objects
-#
-#         # scripts of sprite objects
-#         assert len(background_object.scripts) == 0
-#         assert len(first_object.scripts) == 1
-#         script = first_object.scripts[0]
-#         expected_script = scratch.Script(expected_first_object_first_script_data)
-#         assert script == expected_script
-#
-#         # sprite variables
-#         assert len(background_object._dict_object["variables"]) == 1
-#         assert len(first_object._dict_object["variables"]) == 0
-#
-#     def test_convert_attribute_of_other_object_block(self):
-#         cls = self.__class__
-#         other_object_name = "Stage"
-#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-#             first_script_data = [0, 0, [["whenGreenFlag"],
-#                 ["wait:elapsed:from:", 2],
-#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]
-#             ]]
-#             self.root_info["children"][0]["scripts"] = [first_script_data]
-#             raw_project = scratch.RawProject(self.root_info)
-#             variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
-#             expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [sensor_name]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#             first_script_data[2][2][2] = ["readVariable", variable_name]
-#             expected_first_object_first_script_data = first_script_data
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 1
-#             assert len(first_object.scripts) == 1
-#             script = background_object.scripts[0]
-#             expected_script = scratch.Script(expected_background_object_first_script_data)
-#             assert script == expected_script
-#             script = first_object.scripts[0]
-#             expected_script = scratch.Script(expected_first_object_first_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             stage_object_variables = background_object._dict_object["variables"]
-#             assert len(stage_object_variables) == 2
-#             assert len(first_object._dict_object["variables"]) == 0
-#             assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-#             assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#     def test_convert_attribute_of_other_object_block_encapsulated(self):
-#         cls = self.__class__
-#         other_object_name = "Stage"
-#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-#             first_script_data = [0, 0, [["whenGreenFlag"],
-#                 ["wait:elapsed:from:", 2],
-#                 ["doRepeat", 10,
-#                     [["doIf", False, [["doIfElse", False,
-#                         [["doForever",
-#                             [["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]]
-#                         ]], 0]]]
-#                 ]]
-#             ]]
-#             self.root_info["children"][0]["scripts"] = [first_script_data]
-#             raw_project = scratch.RawProject(self.root_info)
-#             variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
-#             expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
-#                 ['doForever', [
-#                     ["setVar:to:", variable_name, [sensor_name]],
-#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-#                 ]]
-#             ]]
-#             first_script_data[2][2][2][0][2][0][2][0][1][0][2] = ["readVariable", variable_name]
-#             expected_first_object_first_script_data = first_script_data
-#
-#             # validate
-#             assert len(raw_project.objects) == 2
-#             [background_object, first_object] = raw_project.objects
-#
-#             # scripts of sprite objects
-#             assert len(background_object.scripts) == 1
-#             assert len(first_object.scripts) == 1
-#             script = background_object.scripts[0]
-#             expected_script = scratch.Script(expected_background_object_first_script_data)
-#             assert script == expected_script
-#             script = first_object.scripts[0]
-#             expected_script = scratch.Script(expected_first_object_first_script_data)
-#             assert script == expected_script
-#
-#             # sprite variables
-#             stage_object_variables = background_object._dict_object["variables"]
-#             assert len(stage_object_variables) == 2
-#             assert len(first_object._dict_object["variables"]) == 0
-#             assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-#             assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
-#
-#
-# class CommentWorkaround(unittest.TestCase):
-#     COMMENT_DATA_TEMPLATE = {
-#         "objName": "Stage",
-#         "sounds": [],
-#         "costumes": [],
-#         "currentCostumeIndex": 0,
-#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-#         "penLayerID": 0,
-#         "tempoBPM": 60,
-#         "videoAlpha": 0.5,
-#         "children": [],
-#         "info": {}
-#     }
-#
-#     def get_stage(self, scripts, comments):
-#         data = self.COMMENT_DATA_TEMPLATE
-#         data["scriptComments"] = comments
-#         data["scripts"] = scripts
-#         raw_project = scratch.RawProject(data)
-#         self.assertEqual(1, len(raw_project.objects))
-#         return raw_project.objects[0]
-#
-#     @classmethod
-#     def get_comment(cls, blockId, text):
-#         return [0, 0, 0, 0, False, blockId, text]
-#
-#     def test_simple_comment(self):
-#         for blockId in [-1, 0, 1]:
-#             script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1]]]
-#             comment = self.get_comment(1, "test_comment")
-#             stage = self.get_stage([script], [comment])
-#
-#             self.assertEqual(1, len(stage.scripts))
-#             script = stage.scripts[0]
-#             self.assertListEqual([['note:', 'test_comment'], ['wait:elapsed:from:', 1]], script.blocks)
-#
-#     def test_condition_comment(self):
-#         script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1], ["wait:elapsed:from:", ["+", 1, 2]], ["wait:elapsed:from:", 1]]]
-#         comments = [self.get_comment(3, "condition_comment"), self.get_comment(4, "wait_comment")]
-#         stage = self.get_stage([script], comments)
-#
-#         self.assertEqual(1, len(stage.scripts))
-#         script = stage.scripts[0]
-#         expected_blocks = [['wait:elapsed:from:', 1],
-#                            ['note:', 'condition_comment'],
-#                            ['wait:elapsed:from:', ['+', 1, 2]],
-#                            ['note:', 'wait_comment'],
-#                            ['wait:elapsed:from:', 1]]
-#         self.assertListEqual(expected_blocks, script.blocks)
-#
-#     def test_comment_in_if(self):
-#         script = [0, 0, [["whenGreenFlag"], ["doIf", [">", 5, 4], [["wait:elapsed:from:", 1]]], ["wait:elapsed:from:", 1]]]
-#         comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "after_if_comment")]
-#         stage = self.get_stage([script], comments)
-#
-#         self.assertEqual(1, len(stage.scripts))
-#         script = stage.scripts[0]
-#         expected_blocks = [['doIf',
-#                             ['>', 5, 4],
-#                             [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]]],
-#                            ['note:', 'after_if_comment'],
-#                            ['wait:elapsed:from:', 1]]
-#         self.assertListEqual(expected_blocks, script.blocks)
-#
-#     def test_comment_in_else(self):
-#         script = [0, 0, [["whenGreenFlag"], ["doIfElse", [">", 5, 4], [["wait:elapsed:from:", 1]], [["wait:elapsed:from:", 2]]], ["wait:elapsed:from:", 1]]]
-#         comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "in_else_comment"), self.get_comment(5, "after_if_comment")]
-#         stage = self.get_stage([script], comments)
-#
-#         self.assertEqual(1, len(stage.scripts))
-#         script = stage.scripts[0]
-#         expected_blocks = [['doIfElse',
-#                             ['>', 5, 4],
-#                             [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]],
-#                             [['note:', 'in_else_comment'], ['wait:elapsed:from:', 2]]],
-#                            ['note:', 'after_if_comment'],
-#                            ['wait:elapsed:from:', 1]]
-#         self.assertListEqual(expected_blocks, script.blocks)
-#
-#     def test_multiple_comments_same_brick(self):
-#         NUM_COMMENTS = 20
-#         for blockId in [-1, 0, 1, 2]:
-#             script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
-#             comments = [self.get_comment(1, "test_comment_{}".format(i)) for i in range(NUM_COMMENTS)]
-#             stage = self.get_stage([script], comments)
-#
-#             self.assertEqual(1, len(stage.scripts))
-#             script = stage.scripts[0]
-#             expected_blocks = [["note:", "test_comment_{}".format(i)] for i in range(NUM_COMMENTS)][::-1] + [["wait:elapsed:from:", ["+", 1, 2]]]
-#             self.assertListEqual(expected_blocks, script.blocks)
-#
-#     def test_invalid_blocks(self):
-#         scripts = [
-#             [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]],
-#             [0, 0, [["+", 4, 3]]],
-#             [0, 0, [["wait:elapsed:from:", "-", 2, -1]]],
-#             [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
-#         ]
-#         comments = [self.get_comment(i, "comment_{}".format(i)) for i in range(8)]
-#         stage = self.get_stage(scripts, comments)
-#
-#         self.assertEqual(2, len(stage.scripts))
-#         expected_blocks_0 = [['note:', 'comment_0'],
-#                              ['note:', 'comment_1'],
-#                              ['note:', 'comment_2'],
-#                              ['wait:elapsed:from:', ['+', 1, 2]]]
-#         self.assertListEqual(expected_blocks_0, stage.scripts[0].blocks)
-#         expected_blocks_1 = [['note:', 'comment_5'],
-#                              ['note:', 'comment_6'],
-#                              ['note:', 'comment_7'],
-#                              ['wait:elapsed:from:', ['+', 1, 2]]]
-#         self.assertListEqual(expected_blocks_1, stage.scripts[1].blocks)
-#
-#     def test_general_comment_without_scripts(self):
-#         comment = self.get_comment(-1, "general comment")
-#         stage = self.get_stage([], [comment])
-#         self.assertListEqual([], stage.scripts)
+
+class TestBlockInit(unittest.TestCase):
+
+    def test_can_construct_on_correct_input(self):
+        expected_values = (
+            (4, (2, 2, 2, 1)),
+            (1, (2,)),
+            (1, (2,)),
+        )
+        for script_input, [expected_length, expected_block_children_number] in zip(EASY_SCRIPTS, expected_values):
+            assert len(scratch.Script(script_input).blocks) == expected_length
+            blocks = scratch.ScriptElement.from_raw_script(script_input)
+            assert isinstance(blocks, scratch.BlockList) and len(blocks.children) == expected_length
+            nested_blocks = blocks.children
+            assert all(isinstance(block, scratch.ScriptElement) for block in nested_blocks)
+            assert [len(block.children) for block in nested_blocks] == list(expected_block_children_number)
+
+
+class TestScriptElementTree(common_testing.BaseTestCase):
+
+    def test_verify_simple_formula_in_script_element_tree(self):
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]]
+        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]
+
+        script = scratch.Script(script_data)
+        assert script.type == scratch.SCRIPT_GREEN_FLAG
+        assert len(script.arguments) == 0
+        assert script.raw_script == expected_raw_script_data
+        assert script.blocks == expected_raw_script_data[1:]
+        assert isinstance(script.script_element, scratch.BlockList)
+        assert script.script_element.name == '<LIST>'
+        assert len(script.script_element.children) == 1
+
+        script_element_child = script.script_element.children[0]
+        assert script_element_child.name == 'wait:elapsed:from:'
+        assert len(script_element_child.children) == 1
+
+        script_element_child = script_element_child.children[0]
+        assert script_element_child.name == 'randomFrom:to:'
+        assert len(script_element_child.children) == 2
+
+        left_child = script_element_child.children[0]
+        right_child = script_element_child.children[1]
+        assert left_child.name == -100
+        assert len(left_child.children) == 0
+        assert right_child.name == 100
+        assert len(right_child.children) == 0
+
+    def test_verify_complex_formula_in_script_element_tree(self):
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+                        0, ["randomFrom:to:", 0, 100]]]]]
+        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+                        0, ["randomFrom:to:", 0, 100]]]]
+
+        script = scratch.Script(script_data)
+        assert script.type == scratch.SCRIPT_GREEN_FLAG
+        assert len(script.arguments) == 0
+        assert script.raw_script == expected_raw_script_data
+        assert script.blocks == expected_raw_script_data[1:]
+        assert isinstance(script.script_element, scratch.BlockList)
+        assert script.script_element.name == '<LIST>'
+        assert len(script.script_element.children) == 1
+
+        script_element_child = script.script_element.children[0]
+        assert script_element_child.name == 'wait:elapsed:from:'
+        assert len(script_element_child.children) == 1
+
+        script_element_child = script_element_child.children[0]
+        assert script_element_child.name == '+'
+        assert len(script_element_child.children) == 2
+
+        left_child = script_element_child.children[0]
+        right_child = script_element_child.children[1]
+        assert left_child.name == 0
+        assert len(left_child.children) == 0
+        assert right_child.name == 'randomFrom:to:'
+        assert len(right_child.children) == 2
+
+        left_child = right_child.children[0]
+        right_child = right_child.children[1]
+        assert left_child.name == 0
+        assert len(left_child.children) == 0
+        assert right_child.name == 100
+        assert len(right_child.children) == 0
+
+    def test_verify_complex_script_element_tree(self):
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+                        0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]]
+        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+                        0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]
+
+        script = scratch.Script(script_data)
+        assert script.type == scratch.SCRIPT_GREEN_FLAG
+        assert len(script.arguments) == 0
+        assert script.raw_script == expected_raw_script_data
+        assert script.blocks == expected_raw_script_data[1:]
+        assert isinstance(script.script_element, scratch.BlockList)
+        assert script.script_element.name == '<LIST>'
+        assert len(script.script_element.children) == 2
+
+        script_element_child = script.script_element.children[0]
+        assert script_element_child.name == 'wait:elapsed:from:'
+        assert len(script_element_child.children) == 1
+        script_element_child = script_element_child.children[0]
+        assert script_element_child.name == '+'
+        assert len(script_element_child.children) == 2
+
+        left_child = script_element_child.children[0]
+        right_child = script_element_child.children[1]
+        assert left_child.name == 0
+        assert len(left_child.children) == 0
+        assert right_child.name == 'randomFrom:to:'
+        assert len(right_child.children) == 2
+
+        left_child = right_child.children[0]
+        right_child = right_child.children[1]
+        assert left_child.name == 0
+        assert len(left_child.children) == 0
+        assert right_child.name == 100
+        assert len(right_child.children) == 0
+
+        script_element_child = script.script_element.children[1]
+        assert script_element_child.name == 'changeVar:by:'
+        assert len(script_element_child.children) == 2
+
+        left_child = script_element_child.children[0]
+        right_child = script_element_child.children[1]
+        assert left_child.name == 'temp'
+        assert len(left_child.children) == 0
+        assert right_child.name == 0.1
+        assert len(right_child.children) == 0
+
+
+class TestTimerAndResetTimerBlockWorkarounds(unittest.TestCase):
+    TIMER_HELPER_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [{ "objName": "Sprite1", "scripts": None }],
+        "info": {}
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+
+    def test_timer_block(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+        expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+        ]]
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 1
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_script_data)
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+    def test_same_timer_block_twice(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["wait:elapsed:from:", ["timer"]]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+        ]]
+
+        # create project
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 1
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_script_data)
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+    def test_reset_timer_block_with_non_existant_timer_block_should_automatically_add_timer_script(self):
+        cls = self.__class__
+        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]]
+        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+        ]]]
+        script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ['doBroadcastAndWait', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+        ]]
+
+        # create project
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 2
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_scripts_data[0])
+        assert script == expected_script
+        script = background_object.scripts[1]
+        expected_script = scratch.Script(expected_background_object_scripts_data[1])
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+    def test_reset_timer_block_with_existant_timer_block_in_same_object_must_NOT_be_ignored(self):
+        cls = self.__class__
+        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]]
+        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+        ]]]
+        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["timerReset"]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+            ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+        ]]
+
+        # create project
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 2
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_scripts_data[0])
+        assert script == expected_script
+        script = background_object.scripts[1]
+        expected_script = scratch.Script(expected_background_object_scripts_data[1])
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+    def test_reset_timer_block_and_timer_block_within_loop_must_NOT_be_ignored(self):
+        cls = self.__class__
+        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]]
+        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+        ]]]
+        script_data = [0, 0, [["whenGreenFlag"],
+            ["doRepeat", 100, [["wait:elapsed:from:", ["timer"]], ["timerReset"]]]]
+        ]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ["doRepeat", 100, [
+                ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+                ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]]
+        ]]]
+
+        # create project
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 2
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_scripts_data[0])
+        assert script == expected_script
+        script = background_object.scripts[1]
+        expected_script = scratch.Script(expected_background_object_scripts_data[1])
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+    def test_reset_timer_block_with_existant_timer_block_in_other_object_must_NOT_be_ignored(self):
+        cls = self.__class__
+        background_script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [background_script_data]
+        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+            ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+        ]], [0, 0, [['whenGreenFlag'],
+            ['doForever', [
+                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]]
+        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+        ]]]
+
+        # first object scripts
+        first_object_script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
+        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [first_object_script_data]
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+        ]]
+
+        # create project
+        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 3
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_scripts_data[0])
+        assert script == expected_script
+        script = background_object.scripts[1]
+        expected_script = scratch.Script(expected_background_object_scripts_data[1])
+        assert script == expected_script
+        script = background_object.scripts[2]
+        expected_script = scratch.Script(expected_background_object_scripts_data[2])
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+
+class TestBackdropWorkaround(unittest.TestCase):
+    BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [{'baseLayerMD5': ''}, {'baseLayerMD5': ''}, {'baseLayerMD5': ''}],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "scripts": [],
+        "children": [{ "objName": "Sprite1", "scripts": [] }],
+        "info": {}
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+
+    def _setup_objects(self, blocks, backdrop_script = [], multiple_sprites = 1):
+        cls = self.__class__
+        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = [{ "objName": "Sprite1", "scripts": [] }]
+        input_script = [0, 0, [["whenGreenFlag"]]]
+        expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
+
+        # parse backdrop input and output
+        if backdrop_script:
+            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
+            backdrop_script = [backdrop_script]
+
+        # validate backgrounds
+        assert len(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["costumes"]) == 3
+
+        # initialize backdrop scripts
+        for block in set(blocks):
+            if "random" not in block:
+                backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", block]]])
+            else:
+                backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", ['randomFrom:to:', 1.0, 3.0]]]])
+
+        # parse input and expected output
+        for i in range(4):
+            for block in blocks:
+                input_script[2].extend([["startScene", block],["wait:elapsed:from:", 1]])
+                expected_sprite_script[2].extend([["broadcast:", block], ["wait:elapsed:from:", 1]])
+
+        # multiple sprites?
+        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [input_script]
+        if multiple_sprites == 2:
+            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": []})
+            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [input_script]
+
+        # prepare values for return
+        expected_sprite_script = scratch.Script(expected_sprite_script)
+        expected_backdrop = []
+        for script in backdrop_script:
+            expected_backdrop.append(scratch.Script(script))
+        raw_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
+        return {"converted": raw_project, "expected": {"Backdrop": expected_backdrop, "Sprite": [expected_sprite_script]}}
+
+    def test_previous_backdrop_in_single_sprite(self):
+        test_data = self._setup_objects(["previous backdrop"], [])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_multiple_sprites(self):
+        test_data = self._setup_objects(["previous backdrop"], [], 2)
+
+        assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
+        assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+        assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+        assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_multiple_backdrop_scripts_single_sprite(self):
+        test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_multiple_backdrop_scripts_multiple_sprites(self):
+        test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
+
+        assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
+        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+        assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+        assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
+
+    def test_random_backdrop_in_stage(self):
+        cls = self.__class__
+        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
+        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [[0,0,[['whenGreenFlag'], ['startScene', 'random backdrop']]]]
+        expected = scratch.Script([0,0,[['whenGreenFlag'], ['startScene', ['randomFrom:to:', 1.0, 3.0]]]])
+        converted_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
+
+        assert len(converted_project.objects) == 1
+        assert len(converted_project.objects[0].scripts) == 1
+
+        assert converted_project.objects[0].scripts[0] == expected
+
+    def test_next_backdrop_and_previous_backdrop_in_single_sprite(self):
+        test_data = self._setup_objects(["next backdrop", "previous backdrop"], [])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_next_backdrop_and_random_backdrop_in_single_sprite(self):
+        test_data = self._setup_objects(["next backdrop", "random backdrop"], [])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_and_random_backdrop_in_single_sprite(self):
+        test_data = self._setup_objects(["previous backdrop", "random backdrop"], [])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_next_backdrop_and_random_backdrop_in_single_sprite(self):
+        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"], [])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 3 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_single_sprite(self):
+        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
+                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+    def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_multiple_sprites(self):
+        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
+                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
+
+        assert len(test_data["converted"].objects) == 3
+        assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
+        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+
+        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+
+class TestKeyPressedWorkaround(unittest.TestCase):
+    KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [{ "objName": "Sprite1", "scripts": None }],
+        "info": {}
+    }
+
+    KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE = {
+        "doIf": [['doIf', ['keyPressed:', None], None]],
+        "doIfElse": [['doIfElse', ['keyPressed:', None], None, None]],
+        "doUntil": [['doUntil', ['keyPressed:', None], None]],
+        "doWaitUntil": [['doWaitUntil', ['keyPressed:', None]]]
+    }
+
+    KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS = {
+        "or": [['|', ['keyPressed:', None], ['keyPressed:', None]]],
+        "and": [['&', ['keyPressed:', None], ['keyPressed:', None]]],
+        "not": ['not', ['keyPressed:', None]]
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
+
+    def _setup_objects(self, blocks, keys, backdrop_script = [], multiple_sprites = 1, operator = None):
+        cls = self.__class__
+        input_script = [0, 0, [["whenGreenFlag"]]]
+        expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
+
+        if operator is not None:
+            assert len(keys) > 1
+
+        if backdrop_script:
+            cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
+
+        for block in set(blocks):
+            input_script[2].extend(cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block])
+            script_after = cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block]
+            script_after[0][1][0] = "readVariable"
+            script_after[0][1][1] = "S2CC:key_" + str(keys[0])
+            expected_sprite_script[2].extend(script_after)
+
+        if len(set(blocks)) > 1 and (operator == "or" or operator == "and"):
+            operator_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS.get(operator)
+            operator_brick[0][1][1] = str(keys[0])
+            operator_brick[0][2][1] = str(keys[1])
+            input_script[2].extend(operator_brick)
+            for x in [1,2]:
+                for y in [0,1]:
+                    operator_brick[0][x][y] = ("S2CC:key_" + str(keys[x-1])
+                                               if operator_brick[0][x][y] in keys
+                                               else "readVariable")
+            expected_sprite_script[2].extend(operator_brick)
+        elif operator == "not":
+            not_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS["not"]
+            not_brick[1][1] = keys[0]
+            input_script[2].extend(not_brick)
+            not_brick[1][0] = "readVariable"
+            not_brick[1][1] = "S2CC:key_" + str(keys[0])
+            expected_sprite_script[2].extend(not_brick)
+
+        for index in range(multiple_sprites):
+            cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite" + str(index+1), "scripts": [input_script]})
+
+        expected_sprite_script = scratch.Script(expected_sprite_script)
+        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+        return {"converted": raw_project, "expected_sprite": [expected_sprite_script]}
+
+    def test_key_pressed_do_if_block_up_arrow_key(self):
+        test_data = self._setup_objects(["doIf"], ["up arrow"])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_if_else_block_space_key(self):
+        test_data = self._setup_objects(["doIfElse"], ["space"])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_until_block_down_arrow_key(self):
+        test_data = self._setup_objects(["doUntil"], ["down arrow"])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_wait_until_block_any_key(self):
+        test_data = self._setup_objects(["doWaitUntil"], ["any"])
+
+        assert len(test_data["converted"].objects) == 2
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_if_and_do_if_else_blocks_i_key_multiple_sprites(self):
+        test_data = self._setup_objects(["doIf", "doIfElse"], ["i"], [], 3)
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_until_and_do_wait_until_blocks_n_key_multiple_sprites(self):
+        test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space"], [], 3)
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_wait_until_block_any_key_backdrop_script_multiple_sprites(self):
+        test_data = self._setup_objects(["doWaitUntil"], ["any"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3)
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 1
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_until_and_do_wait_until_blocks_space_and_i_keys_multiple_sprites_and_and_block(self):
+        test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space", "i"], [], 3, "and")
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_if_and_do_if_else_blocks_any_and_up_arrow_keys_multiple_sprites_and_or_block(self):
+        test_data = self._setup_objects(["doIf", "doIfElse"], ["any", "up arrow"], [], 3, "or")
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 0
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed_do_until_do_wait_until_do_if_and_do_if_else_blocks_right_arrow_and_y_keys_backdrop_script_multiple_sprites_and_not_block(self):
+        test_data = self._setup_objects(["doUntil", "doWaitUntil", "doIf", "doIfElse"], ["right arrow", "y"],
+                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3, "not")
+
+        assert len(test_data["converted"].objects) == 4
+        assert len(test_data["converted"].objects[0].scripts) == 1
+        assert len(test_data["converted"].objects[1].scripts) == 1
+
+        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+
+    def test_key_pressed(self):
+        cls = self.__class__
+        script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["keyPressed:", "w"],[["changeYposBy:", 1]]]]]]]
+        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
+        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+        key_pressed_var_name = scratch.S2CC_KEY_VARIABLE_NAME + "w"
+        expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["readVariable", key_pressed_var_name],[["changeYposBy:", 1]]]]]]]
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, sprite_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        script = sprite_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+    def test_key_pressed_with_formula(self):
+        cls = self.__class__
+        script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", [u'keyPressed:', [u'+', 3.0, 2.0]],[["changeYposBy:", 1]]]]]]]
+        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
+        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+        expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever",
+                                                                    [["doIf", ["=", "space", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_space"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "up arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_up arrow"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "down arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_down arrow"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "left arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_left arrow"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "right arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_right arrow"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "1", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_1"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "2", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_2"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "3", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_3"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "4", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_4"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "5", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_5"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "6", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_6"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "7", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_7"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "8", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_8"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "9", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_9"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "0", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_0"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "q", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_q"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "w", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_w"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "e", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_e"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "r", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_r"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "t", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_t"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "z", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_z"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "u", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_u"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "i", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_i"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "o", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_o"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "p", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_p"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "a", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_a"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "s", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_s"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "d", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_d"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "f", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_f"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "g", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_g"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "h", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_h"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "j", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_j"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "k", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_k"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "l", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_l"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "y", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_y"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "x", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_x"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "c", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_c"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "v", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_v"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "b", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_b"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "n", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_n"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "m", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_m"], [["changeYposBy:", 1]]]]],
+                                                                     ["doIf", ["=", "any", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_any"], [["changeYposBy:", 1]]]]]]]]]
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, sprite_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        script = sprite_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+class TestDistanceBlockWorkaround(unittest.TestCase):
+    DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [{ "objName": "Sprite1", "scripts": None },
+                     { "objName": "Sprite2", "scripts": None }],
+        "info": {}
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+
+    def test_single_distance_block(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+              ]
+            ]]
+        ]]]
+        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+            ["doForever", [
+              ["setVar:to:", position_x_var_name, ["xpos"]],
+              ["setVar:to:", position_y_var_name, ["ypos"]],
+              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 1
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 2
+        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+
+    def test_two_distance_blocks_in_same_object(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]],
+                              ["forward:", ["distanceTo:", "Sprite2"]]]]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+              ]
+            ]]
+        ], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+              ]
+            ]]
+        ]]]
+        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+            ["doForever", [
+              ["setVar:to:", position_x_var_name, ["xpos"]],
+              ["setVar:to:", position_y_var_name, ["ypos"]],
+              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 1
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 2
+        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+
+    def test_two_distance_blocks_in_different_objects(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+        expected_background_and_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+              ]
+            ]]
+        ]]]
+        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+            ["doForever", [
+              ["setVar:to:", position_x_var_name, ["xpos"]],
+              ["setVar:to:", position_y_var_name, ["ypos"]],
+              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 1
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_and_first_object_script_data)
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_background_and_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 1
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 2
+        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+
+    def test_two_different_distance_blocks_in_different_objects(self):
+        cls = self.__class__
+        script_data0 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+        script_data2 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite1"]]]]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data0]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = []
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [script_data2]
+        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+        position_x_var_name1 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite1"
+        position_y_var_name1 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite1"
+        position_x_var_name2 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+        position_y_var_name2 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+        expected_background_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]]
+              ]
+            ]]
+        ]]]
+        expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+            ["doForever", [
+              ["setVar:to:", position_x_var_name1, ["xpos"]],
+              ["setVar:to:", position_y_var_name1, ["ypos"]],
+              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]
+        expected_second_object_scripts_data = [[0, 0, [["whenGreenFlag"], ['forward:',
+            ["computeFunction:of:", "sqrt", ["+",
+              ["*",
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]],
+                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]]
+              ], ["*",
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]],
+                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]]
+              ]
+            ]]
+        ]]], [0, 0, [['whenGreenFlag'],
+            ["doForever", [
+              ["setVar:to:", position_x_var_name2, ["xpos"]],
+              ["setVar:to:", position_y_var_name2, ["ypos"]],
+              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+            ]]
+        ]]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 1
+        script = background_object.scripts[0]
+        expected_script = scratch.Script(expected_background_object_script_data)
+        assert script == expected_script
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 2
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_scripts_data[0])
+        assert script == expected_script
+        script = second_object.scripts[1]
+        expected_script = scratch.Script(expected_second_object_scripts_data[1])
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 4
+        assert global_variables[0] == { "name": position_x_var_name2, "value": 0, "isPersistent": False }
+        assert global_variables[1] == { "name": position_y_var_name2, "value": 0, "isPersistent": False }
+        assert global_variables[2] == { "name": position_x_var_name1, "value": 0, "isPersistent": False }
+        assert global_variables[3] == { "name": position_y_var_name1, "value": 0, "isPersistent": False }
+
+    def test_single_distance_block_to_mouse_pointer(self):
+        cls = self.__class__
+        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "_mouse_"]]]]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "_mouse_"
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "_mouse_"
+        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ["forward:",
+            ["computeFunction:of:", "sqrt",
+                ["+",
+                    ["*",
+                        ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+                        ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+                    ],
+                    ["*",
+                        ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+                        ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+                    ]
+                 ]]
+            ]]]
+
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # mouse-sprite will be created during conversion and not in the pre-processing ->
+        # for now, the second sprite is irrelevant
+        assert len(second_object.scripts) == 0
+
+        # global variables; for the mouse-pointer workaround, the variables are created during conversion
+        # and not in the pre-process
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 0
+
+        # check the flag -> indicates that mouse-sprite has to be created during conversion
+        assert raw_project._has_mouse_position_script
+
+class TestGlideToObjectBlockWorkaround(unittest.TestCase):
+    GLIDE_TO_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [{ "objName": "Sprite1", "scripts": None },
+                     { "objName": "Sprite2", "scripts": None }],
+        "info": {}
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["scripts"] = []
+
+    def test_glide_to_different_sprite(self):
+        cls = self.__class__
+        spinner_selection = "Sprite2"
+        time_in_sec = "1"
+        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
+        expected_first_object_script_data = \
+            [0, 0, [["whenGreenFlag"], [
+                "glideSecs:toX:y:elapsed:from:",
+                 time_in_sec,
+                ["readVariable", position_x_var_name],
+                ["readVariable", position_y_var_name]
+            ]]]
+
+        expected_second_object_script_data = \
+            [0, 0, [["whenGreenFlag"],[
+                    "doForever", [
+                        ["setVar:to:", position_x_var_name, ["xpos"]],
+                        ["setVar:to:", position_y_var_name, ["ypos"]],
+                        ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                 ]]
+            ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 1
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_script_data)
+        assert script == expected_script
+
+        # global variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 2
+        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+
+    def test_glide_to_random_position(self):
+        cls = self.__class__
+        spinner_selection = "_random_"
+        time_in_sec = "1"
+        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+
+        # random position also needs a workaround -> different resolutions in scratch and pocket code
+        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+
+        expected_first_object_script_data = \
+            [0, 0, [["whenGreenFlag"],[
+                "glideSecs:toX:y:elapsed:from:",
+                time_in_sec,
+                ["randomFrom:to:", left_x, right_x],
+                ["randomFrom:to:", lower_y, upper_y]
+            ]]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 0
+
+    def test_glide_to_mouse_poointer(self):
+        cls = self.__class__
+        spinner_selection = "_mouse_"
+        time_in_sec = "1"
+        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
+        expected_first_object_script_data = \
+            [0, 0, [["whenGreenFlag"], [
+                "glideSecs:toX:y:elapsed:from:",
+                time_in_sec,
+                ["readVariable", position_x_var_name],
+                ["readVariable", position_y_var_name]
+            ]]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # same as in the 'distanceTo'-block workaround, the mouse-sprite is created during
+        # conversion and not in the pre-processing -> no mouse-sprite yet
+        assert len(second_object.scripts) == 0
+
+        # global variables; for the mouse-pointer workaround, the variables are created during conversion
+        # and not in the pre-process
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 0
+
+        # check the flag -> indicates that mouse-sprite has to be created during conversion
+        assert raw_project._has_mouse_position_script
+
+    def test_glide_to_random_single_nested(self):
+        cls = self.__class__
+        spinner_selection = "_random_"
+        time_in_sec = "1"
+        script_data = [0, 0, [["whenGreenFlag"], ["doForever", ["glideTo:", time_in_sec, spinner_selection]]]]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+
+        # random position also needs a workaround -> different resolutions in scratch and pocket code
+        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+
+        expected_first_object_script_data = \
+            [0, 0, [["whenGreenFlag"],
+                ["doForever",
+                    ["glideSecs:toX:y:elapsed:from:",
+                        time_in_sec,
+                        ["randomFrom:to:", left_x, right_x],
+                        ["randomFrom:to:", lower_y, upper_y]
+                    ]
+                ]
+            ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 0
+
+    def test_glide_to_objects_double_nested(self):
+        cls = self.__class__
+        spinner_selection_random = "_random_"
+        spinner_selection_mouse = "_mouse_"
+        time_in_sec = "1"
+
+        script_data = [0, 0, [["whenGreenFlag"],
+                                ["doForever",
+                                    ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
+                                        ["glideTo:", time_in_sec, spinner_selection_random],
+                                        ["glideTo:", time_in_sec, spinner_selection_mouse]
+                                    ]
+                                ]
+                            ]]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+
+        # variables for x and y positions of the mouse-pointer
+        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection_mouse
+        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection_mouse
+
+        # random position option also needs a workaround -> different resolutions in scratch and pocket code
+        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+
+        expected_first_object_script_data = \
+            [0, 0, [["whenGreenFlag"],
+                    ["doForever",
+                        ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
+                            ["glideSecs:toX:y:elapsed:from:",
+                                time_in_sec,
+                                ["randomFrom:to:", left_x, right_x],
+                                ["randomFrom:to:", lower_y, upper_y]
+                            ],
+                            ["glideSecs:toX:y:elapsed:from:",
+                                time_in_sec,
+                                ["readVariable", position_x_var_name],
+                                ["readVariable", position_y_var_name]
+                            ]
+                        ]
+                    ]
+            ]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # background object
+        assert len(background_object.scripts) == 0
+
+        # first object
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_script_data)
+        assert script == expected_script
+
+        # second object
+        assert len(second_object.scripts) == 0
+
+
+class TestShowSensorBlockWorkarounds(unittest.TestCase):
+    SENSOR_HELPER_OBJECTS_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [{ "objName": "Sprite1", "scripts": [] }],
+        "info": {}
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+        self.original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"][:]
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        cls = self.__class__
+        cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = self.original_child_objects[:]
+
+    def test_convert_show_sensor_without_parameter_block(self):
+        cls = self.__class__
+        sprite_name = "Sprite1"
+        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+        for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+                "target": sprite_name,
+                "cmd": command_name,
+                "param": None,
+                "visible": True
+            }]
+
+            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
+            expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [command_name]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 0
+            assert len(first_object.scripts) == 1
+            script = first_object.scripts[0]
+            expected_script = scratch.Script(expected_first_object_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(background_object._dict_object["variables"]) == 0
+            first_object_variables = first_object._dict_object["variables"]
+            assert len(first_object_variables) == 1
+            assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_show_sensor_with_parameter_block(self):
+        cls = self.__class__
+        sprite_name = "Sprite1"
+        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+        for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+                "target": sprite_name,
+                "cmd": command_name,
+                "param": param,
+                "visible": True
+            }]
+
+            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
+            expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [command_name, param]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 0
+            assert len(first_object.scripts) == 1
+            script = first_object.scripts[0]
+            expected_script = scratch.Script(expected_first_object_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(background_object._dict_object["variables"]) == 0
+            first_object_variables = first_object._dict_object["variables"]
+            assert len(first_object_variables) == 1
+            assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_stage_specific_show_sensor_without_parameter_block(self):
+        cls = self.__class__
+        sprite_name = "Stage"
+        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+        for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+                "target": sprite_name,
+                "cmd": command_name,
+                "param": None,
+                "visible": True
+            }]
+
+            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
+            expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [command_name]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(first_object.scripts) == 0
+            assert len(background_object.scripts) == 1
+            script = background_object.scripts[0]
+            expected_script = scratch.Script(expected_stage_object_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(first_object._dict_object["variables"]) == 0
+            stage_object_variables = background_object._dict_object["variables"]
+            assert len(stage_object_variables) == 1
+            assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_stage_specific_show_sensor_with_parameter_block(self):
+        cls = self.__class__
+        sprite_name = "Stage"
+        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+        for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+                "target": sprite_name,
+                "cmd": command_name,
+                "param": param,
+                "visible": True
+            }]
+
+            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
+            expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [command_name, param]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(first_object.scripts) == 0
+            assert len(background_object.scripts) == 1
+            script = background_object.scripts[0]
+            expected_script = scratch.Script(expected_stage_object_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(first_object._dict_object["variables"]) == 0
+            stage_object_variables = background_object._dict_object["variables"]
+            assert len(stage_object_variables) == 1
+            assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+
+class TestGetAttributeBlockWorkarounds(unittest.TestCase):
+
+    ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP = {
+        "x position": "xpos",
+        "y position": "ypos",
+        "direction": "heading",
+        "costume #": "costumeIndex",
+        "costume name": "costumeName",
+        "size": "scale",
+        "volume": "volume"
+    }
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        cls = self.__class__
+        self.root_info = {
+            "objName": "Stage",
+            "sounds": [],
+            "costumes": [],
+            "currentCostumeIndex": 0,
+            "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+            "penLayerID": 0,
+            "tempoBPM": 60,
+            "videoAlpha": 0.5,
+            "children": [{ "objName": "Sprite1", "scripts": [] }],
+            "scripts": [],
+            "variables": [{ "name": "result", "value": 1, "isPersistent": False }],
+            "info": {}
+        }
+
+    def test_convert_global_variable_attribute_block(self):
+        cls = self.__class__
+        variable_name = "result"
+        first_script_data = [0, 0, [["whenGreenFlag"],
+            ["wait:elapsed:from:", 2],
+            ["setVar:to:", "result", ["getAttribute:of:", variable_name, "_stage_"]]
+        ]]
+        self.root_info["children"][0]["scripts"] = [first_script_data]
+        raw_project = scratch.RawProject(self.root_info)
+        first_script_data[2][2][2] = ["readVariable", variable_name]
+        expected_first_object_first_script_data = first_script_data
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # scripts of sprite objects
+        assert len(background_object.scripts) == 0
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_first_script_data)
+        assert script == expected_script
+
+        # sprite variables
+        global_variables = background_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert len(first_object._dict_object["variables"]) == 0
+        assert global_variables[0] == { "name": variable_name, "value": 1, "isPersistent": False }
+
+    def test_convert_local_variable_of_same_object_attribute_block(self):
+        cls = self.__class__
+        sprite_name = "Sprite1"
+        variable_name = "localVariable"
+        first_script_data = [0, 0, [["whenGreenFlag"],
+            ["wait:elapsed:from:", 2],
+            ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name]]
+        ]]
+        self.root_info["children"][0]["scripts"] = [first_script_data]
+        self.root_info["children"][0]["variables"] = [{ "name": variable_name, "value": 0, "isPersistent": False }]
+        raw_project = scratch.RawProject(self.root_info)
+        first_script_data[2][2][2] = ["readVariable", variable_name]
+        expected_first_object_first_script_data = first_script_data
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # scripts of sprite objects
+        assert len(background_object.scripts) == 0
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_first_script_data)
+        assert script == expected_script
+
+        # sprite variables
+        global_variables = background_object._dict_object["variables"]
+        first_object_variables = first_object._dict_object["variables"]
+        assert len(global_variables) == 1
+        assert len(first_object_variables) == 1
+        assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+        assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_local_variable_of_other_object_attribute_block(self):
+        cls = self.__class__
+        sprite_name_of_other_object = "Sprite2"
+        variable_name = "localVariableOfSprite2"
+        self.root_info["children"] += [{
+            "objName": sprite_name_of_other_object,
+            "scripts": [],
+            "variables": [{ "name": variable_name, "value": 0, "isPersistent": False }]
+        }]
+        first_script_data = [0, 0, [["whenGreenFlag"],
+            ["wait:elapsed:from:", 2],
+            ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name_of_other_object]]
+        ]]
+        self.root_info["children"][0]["scripts"] = [first_script_data]
+        raw_project = scratch.RawProject(self.root_info)
+        helper_variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_readVariable:{}".format(sprite_name_of_other_object, variable_name)
+        first_script_data[2][2][2] = ["readVariable", helper_variable_name]
+        expected_first_object_first_script_data = first_script_data
+        expected_second_object_first_script_data = [0, 0, [["whenGreenFlag"], ["doForever", [
+            ["setVar:to:", helper_variable_name, ["readVariable", variable_name]],
+            ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+        ]]]]
+
+        # validate
+        assert len(raw_project.objects) == 3
+        [background_object, first_object, second_object] = raw_project.objects
+
+        # scripts of sprite objects
+        assert len(background_object.scripts) == 0
+        assert len(first_object.scripts) == 1
+        assert len(second_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_first_script_data)
+        assert script == expected_script
+        script = second_object.scripts[0]
+        expected_script = scratch.Script(expected_second_object_first_script_data)
+        assert script == expected_script
+
+        # sprite variables
+        global_variables = background_object._dict_object["variables"]
+        second_object_variables = second_object._dict_object["variables"]
+        assert len(global_variables) == 2
+        assert len(first_object._dict_object["variables"]) == 0
+        assert len(second_object_variables) == 1
+        assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+        assert global_variables[1] == { "name": helper_variable_name, "value": 0, "isPersistent": False }
+        assert second_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_background_specific_attributes_of_same_object_block(self):
+        cls = self.__class__
+        stage_name = "Stage"
+        for attribute_name, sensor_name in [("backdrop #", "backgroundIndex"), ("backdrop name", "sceneName")]:
+            first_script_data = [0, 0, [["whenGreenFlag"],
+                ["wait:elapsed:from:", 2],
+                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, stage_name]]
+            ]]
+            self.root_info["scripts"] = [first_script_data]
+            raw_project = scratch.RawProject(self.root_info)
+            first_script_data[2][2][2] = [sensor_name]
+            expected_stage_object_first_script_data = first_script_data
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 1
+            assert len(first_object.scripts) == 0
+            script = background_object.scripts[0]
+            expected_script = scratch.Script(expected_stage_object_first_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(background_object._dict_object["variables"]) == 1
+            assert len(first_object._dict_object["variables"]) == 0
+
+    def test_convert_attribute_of_same_object_block(self):
+        cls = self.__class__
+        sprite_name = "Sprite1"
+        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+            first_script_data = [0, 0, [["whenGreenFlag"],
+                ["wait:elapsed:from:", 2],
+                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, sprite_name]]
+            ]]
+            self.root_info["children"][0]["scripts"] = [first_script_data]
+            raw_project = scratch.RawProject(self.root_info)
+            first_script_data[2][2][2] = [sensor_name]
+            expected_first_object_first_script_data = first_script_data
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 0
+            assert len(first_object.scripts) == 1
+            script = first_object.scripts[0]
+            expected_script = scratch.Script(expected_first_object_first_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            assert len(background_object._dict_object["variables"]) == 1
+            assert len(first_object._dict_object["variables"]) == 0
+
+    def test_should_convert_attribute_with_formula_block_to_zero_placeholder(self):
+        cls = self.__class__
+        first_script_data = [0, 0, [["whenGreenFlag"],
+            ["wait:elapsed:from:", 2],
+            ["setVar:to:", "result", ["getAttribute:of:", "x position", ["+", 1, 2]]]
+        ]]
+        self.root_info["children"][0]["scripts"] = [first_script_data]
+        raw_project = scratch.RawProject(self.root_info)
+        first_script_data[2][2][2] = 0
+        expected_first_object_first_script_data = first_script_data
+
+        # validate
+        assert len(raw_project.objects) == 2
+        [background_object, first_object] = raw_project.objects
+
+        # scripts of sprite objects
+        assert len(background_object.scripts) == 0
+        assert len(first_object.scripts) == 1
+        script = first_object.scripts[0]
+        expected_script = scratch.Script(expected_first_object_first_script_data)
+        assert script == expected_script
+
+        # sprite variables
+        assert len(background_object._dict_object["variables"]) == 1
+        assert len(first_object._dict_object["variables"]) == 0
+
+    def test_convert_attribute_of_other_object_block(self):
+        cls = self.__class__
+        other_object_name = "Stage"
+        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+            first_script_data = [0, 0, [["whenGreenFlag"],
+                ["wait:elapsed:from:", 2],
+                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]
+            ]]
+            self.root_info["children"][0]["scripts"] = [first_script_data]
+            raw_project = scratch.RawProject(self.root_info)
+            variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
+            expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [sensor_name]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+            first_script_data[2][2][2] = ["readVariable", variable_name]
+            expected_first_object_first_script_data = first_script_data
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 1
+            assert len(first_object.scripts) == 1
+            script = background_object.scripts[0]
+            expected_script = scratch.Script(expected_background_object_first_script_data)
+            assert script == expected_script
+            script = first_object.scripts[0]
+            expected_script = scratch.Script(expected_first_object_first_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            stage_object_variables = background_object._dict_object["variables"]
+            assert len(stage_object_variables) == 2
+            assert len(first_object._dict_object["variables"]) == 0
+            assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+            assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+    def test_convert_attribute_of_other_object_block_encapsulated(self):
+        cls = self.__class__
+        other_object_name = "Stage"
+        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+            first_script_data = [0, 0, [["whenGreenFlag"],
+                ["wait:elapsed:from:", 2],
+                ["doRepeat", 10,
+                    [["doIf", False, [["doIfElse", False,
+                        [["doForever",
+                            [["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]]
+                        ]], 0]]]
+                ]]
+            ]]
+            self.root_info["children"][0]["scripts"] = [first_script_data]
+            raw_project = scratch.RawProject(self.root_info)
+            variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
+            expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
+                ['doForever', [
+                    ["setVar:to:", variable_name, [sensor_name]],
+                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+                ]]
+            ]]
+            first_script_data[2][2][2][0][2][0][2][0][1][0][2] = ["readVariable", variable_name]
+            expected_first_object_first_script_data = first_script_data
+
+            # validate
+            assert len(raw_project.objects) == 2
+            [background_object, first_object] = raw_project.objects
+
+            # scripts of sprite objects
+            assert len(background_object.scripts) == 1
+            assert len(first_object.scripts) == 1
+            script = background_object.scripts[0]
+            expected_script = scratch.Script(expected_background_object_first_script_data)
+            assert script == expected_script
+            script = first_object.scripts[0]
+            expected_script = scratch.Script(expected_first_object_first_script_data)
+            assert script == expected_script
+
+            # sprite variables
+            stage_object_variables = background_object._dict_object["variables"]
+            assert len(stage_object_variables) == 2
+            assert len(first_object._dict_object["variables"]) == 0
+            assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+            assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
+
+
+class CommentWorkaround(unittest.TestCase):
+    COMMENT_DATA_TEMPLATE = {
+        "objName": "Stage",
+        "sounds": [],
+        "costumes": [],
+        "currentCostumeIndex": 0,
+        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+        "penLayerID": 0,
+        "tempoBPM": 60,
+        "videoAlpha": 0.5,
+        "children": [],
+        "info": {}
+    }
+
+    def get_stage(self, scripts, comments):
+        data = self.COMMENT_DATA_TEMPLATE
+        data["scriptComments"] = comments
+        data["scripts"] = scripts
+        raw_project = scratch.RawProject(data)
+        self.assertEqual(1, len(raw_project.objects))
+        return raw_project.objects[0]
+
+    @classmethod
+    def get_comment(cls, blockId, text):
+        return [0, 0, 0, 0, False, blockId, text]
+
+    def test_simple_comment(self):
+        for blockId in [-1, 0, 1]:
+            script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1]]]
+            comment = self.get_comment(1, "test_comment")
+            stage = self.get_stage([script], [comment])
+
+            self.assertEqual(1, len(stage.scripts))
+            script = stage.scripts[0]
+            self.assertListEqual([['note:', 'test_comment'], ['wait:elapsed:from:', 1]], script.blocks)
+
+    def test_condition_comment(self):
+        script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1], ["wait:elapsed:from:", ["+", 1, 2]], ["wait:elapsed:from:", 1]]]
+        comments = [self.get_comment(3, "condition_comment"), self.get_comment(4, "wait_comment")]
+        stage = self.get_stage([script], comments)
+
+        self.assertEqual(1, len(stage.scripts))
+        script = stage.scripts[0]
+        expected_blocks = [['wait:elapsed:from:', 1],
+                           ['note:', 'condition_comment'],
+                           ['wait:elapsed:from:', ['+', 1, 2]],
+                           ['note:', 'wait_comment'],
+                           ['wait:elapsed:from:', 1]]
+        self.assertListEqual(expected_blocks, script.blocks)
+
+    def test_comment_in_if(self):
+        script = [0, 0, [["whenGreenFlag"], ["doIf", [">", 5, 4], [["wait:elapsed:from:", 1]]], ["wait:elapsed:from:", 1]]]
+        comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "after_if_comment")]
+        stage = self.get_stage([script], comments)
+
+        self.assertEqual(1, len(stage.scripts))
+        script = stage.scripts[0]
+        expected_blocks = [['doIf',
+                            ['>', 5, 4],
+                            [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]]],
+                           ['note:', 'after_if_comment'],
+                           ['wait:elapsed:from:', 1]]
+        self.assertListEqual(expected_blocks, script.blocks)
+
+    def test_comment_in_else(self):
+        script = [0, 0, [["whenGreenFlag"], ["doIfElse", [">", 5, 4], [["wait:elapsed:from:", 1]], [["wait:elapsed:from:", 2]]], ["wait:elapsed:from:", 1]]]
+        comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "in_else_comment"), self.get_comment(5, "after_if_comment")]
+        stage = self.get_stage([script], comments)
+
+        self.assertEqual(1, len(stage.scripts))
+        script = stage.scripts[0]
+        expected_blocks = [['doIfElse',
+                            ['>', 5, 4],
+                            [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]],
+                            [['note:', 'in_else_comment'], ['wait:elapsed:from:', 2]]],
+                           ['note:', 'after_if_comment'],
+                           ['wait:elapsed:from:', 1]]
+        self.assertListEqual(expected_blocks, script.blocks)
+
+    def test_multiple_comments_same_brick(self):
+        NUM_COMMENTS = 20
+        for blockId in [-1, 0, 1, 2]:
+            script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
+            comments = [self.get_comment(1, "test_comment_{}".format(i)) for i in range(NUM_COMMENTS)]
+            stage = self.get_stage([script], comments)
+
+            self.assertEqual(1, len(stage.scripts))
+            script = stage.scripts[0]
+            expected_blocks = [["note:", "test_comment_{}".format(i)] for i in range(NUM_COMMENTS)][::-1] + [["wait:elapsed:from:", ["+", 1, 2]]]
+            self.assertListEqual(expected_blocks, script.blocks)
+
+    def test_invalid_blocks(self):
+        scripts = [
+            [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]],
+            [0, 0, [["+", 4, 3]]],
+            [0, 0, [["wait:elapsed:from:", "-", 2, -1]]],
+            [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
+        ]
+        comments = [self.get_comment(i, "comment_{}".format(i)) for i in range(8)]
+        stage = self.get_stage(scripts, comments)
+
+        self.assertEqual(2, len(stage.scripts))
+        expected_blocks_0 = [['note:', 'comment_0'],
+                             ['note:', 'comment_1'],
+                             ['note:', 'comment_2'],
+                             ['wait:elapsed:from:', ['+', 1, 2]]]
+        self.assertListEqual(expected_blocks_0, stage.scripts[0].blocks)
+        expected_blocks_1 = [['note:', 'comment_5'],
+                             ['note:', 'comment_6'],
+                             ['note:', 'comment_7'],
+                             ['wait:elapsed:from:', ['+', 1, 2]]]
+        self.assertListEqual(expected_blocks_1, stage.scripts[1].blocks)
+
+    def test_general_comment_without_scripts(self):
+        comment = self.get_comment(-1, "general comment")
+        stage = self.get_stage([], [comment])
+        self.assertListEqual([], stage.scripts)
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/src/scratchtocatrobat/scratch/test_scratch.py
+++ b/src/scratchtocatrobat/scratch/test_scratch.py
@@ -323,2029 +323,2029 @@ class TestScriptFunc(unittest.TestCase):
         assert [block[0] for block in self.script.blocks] == expected_block_names
         assert self.script.raw_script == self.input_data[2]
 
-
-class TestBlockInit(unittest.TestCase):
-
-    def test_can_construct_on_correct_input(self):
-        expected_values = (
-            (4, (2, 2, 2, 1)),
-            (1, (2,)),
-            (1, (2,)),
-        )
-        for script_input, [expected_length, expected_block_children_number] in zip(EASY_SCRIPTS, expected_values):
-            assert len(scratch.Script(script_input).blocks) == expected_length
-            blocks = scratch.ScriptElement.from_raw_script(script_input)
-            assert isinstance(blocks, scratch.BlockList) and len(blocks.children) == expected_length
-            nested_blocks = blocks.children
-            assert all(isinstance(block, scratch.ScriptElement) for block in nested_blocks)
-            assert [len(block.children) for block in nested_blocks] == list(expected_block_children_number)
-
-
-class TestScriptElementTree(common_testing.BaseTestCase):
-
-    def test_verify_simple_formula_in_script_element_tree(self):
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]]
-        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]
-
-        script = scratch.Script(script_data)
-        assert script.type == scratch.SCRIPT_GREEN_FLAG
-        assert len(script.arguments) == 0
-        assert script.raw_script == expected_raw_script_data
-        assert script.blocks == expected_raw_script_data[1:]
-        assert isinstance(script.script_element, scratch.BlockList)
-        assert script.script_element.name == '<LIST>'
-        assert len(script.script_element.children) == 1
-
-        script_element_child = script.script_element.children[0]
-        assert script_element_child.name == 'wait:elapsed:from:'
-        assert len(script_element_child.children) == 1
-
-        script_element_child = script_element_child.children[0]
-        assert script_element_child.name == 'randomFrom:to:'
-        assert len(script_element_child.children) == 2
-
-        left_child = script_element_child.children[0]
-        right_child = script_element_child.children[1]
-        assert left_child.name == -100
-        assert len(left_child.children) == 0
-        assert right_child.name == 100
-        assert len(right_child.children) == 0
-
-    def test_verify_complex_formula_in_script_element_tree(self):
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-                        0, ["randomFrom:to:", 0, 100]]]]]
-        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-                        0, ["randomFrom:to:", 0, 100]]]]
-
-        script = scratch.Script(script_data)
-        assert script.type == scratch.SCRIPT_GREEN_FLAG
-        assert len(script.arguments) == 0
-        assert script.raw_script == expected_raw_script_data
-        assert script.blocks == expected_raw_script_data[1:]
-        assert isinstance(script.script_element, scratch.BlockList)
-        assert script.script_element.name == '<LIST>'
-        assert len(script.script_element.children) == 1
-
-        script_element_child = script.script_element.children[0]
-        assert script_element_child.name == 'wait:elapsed:from:'
-        assert len(script_element_child.children) == 1
-
-        script_element_child = script_element_child.children[0]
-        assert script_element_child.name == '+'
-        assert len(script_element_child.children) == 2
-
-        left_child = script_element_child.children[0]
-        right_child = script_element_child.children[1]
-        assert left_child.name == 0
-        assert len(left_child.children) == 0
-        assert right_child.name == 'randomFrom:to:'
-        assert len(right_child.children) == 2
-
-        left_child = right_child.children[0]
-        right_child = right_child.children[1]
-        assert left_child.name == 0
-        assert len(left_child.children) == 0
-        assert right_child.name == 100
-        assert len(right_child.children) == 0
-
-    def test_verify_complex_script_element_tree(self):
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-                        0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]]
-        expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
-                        0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]
-
-        script = scratch.Script(script_data)
-        assert script.type == scratch.SCRIPT_GREEN_FLAG
-        assert len(script.arguments) == 0
-        assert script.raw_script == expected_raw_script_data
-        assert script.blocks == expected_raw_script_data[1:]
-        assert isinstance(script.script_element, scratch.BlockList)
-        assert script.script_element.name == '<LIST>'
-        assert len(script.script_element.children) == 2
-
-        script_element_child = script.script_element.children[0]
-        assert script_element_child.name == 'wait:elapsed:from:'
-        assert len(script_element_child.children) == 1
-        script_element_child = script_element_child.children[0]
-        assert script_element_child.name == '+'
-        assert len(script_element_child.children) == 2
-
-        left_child = script_element_child.children[0]
-        right_child = script_element_child.children[1]
-        assert left_child.name == 0
-        assert len(left_child.children) == 0
-        assert right_child.name == 'randomFrom:to:'
-        assert len(right_child.children) == 2
-
-        left_child = right_child.children[0]
-        right_child = right_child.children[1]
-        assert left_child.name == 0
-        assert len(left_child.children) == 0
-        assert right_child.name == 100
-        assert len(right_child.children) == 0
-
-        script_element_child = script.script_element.children[1]
-        assert script_element_child.name == 'changeVar:by:'
-        assert len(script_element_child.children) == 2
-
-        left_child = script_element_child.children[0]
-        right_child = script_element_child.children[1]
-        assert left_child.name == 'temp'
-        assert len(left_child.children) == 0
-        assert right_child.name == 0.1
-        assert len(right_child.children) == 0
-
-
-class TestTimerAndResetTimerBlockWorkarounds(unittest.TestCase):
-    TIMER_HELPER_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [{ "objName": "Sprite1", "scripts": None }],
-        "info": {}
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-
-    def test_timer_block(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-        expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-        ]]
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 1
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_script_data)
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-    def test_same_timer_block_twice(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["wait:elapsed:from:", ["timer"]]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-        ]]
-
-        # create project
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 1
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_script_data)
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-    def test_reset_timer_block_with_non_existant_timer_block_should_automatically_add_timer_script(self):
-        cls = self.__class__
-        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]]
-        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-        ]]]
-        script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ['doBroadcastAndWait', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-        ]]
-
-        # create project
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 2
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_scripts_data[0])
-        assert script == expected_script
-        script = background_object.scripts[1]
-        expected_script = scratch.Script(expected_background_object_scripts_data[1])
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-    def test_reset_timer_block_with_existant_timer_block_in_same_object_must_NOT_be_ignored(self):
-        cls = self.__class__
-        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]]
-        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-        ]]]
-        script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["timerReset"]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-            ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-        ]]
-
-        # create project
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 2
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_scripts_data[0])
-        assert script == expected_script
-        script = background_object.scripts[1]
-        expected_script = scratch.Script(expected_background_object_scripts_data[1])
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-    def test_reset_timer_block_and_timer_block_within_loop_must_NOT_be_ignored(self):
-        cls = self.__class__
-        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]]
-        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-        ]]]
-        script_data = [0, 0, [["whenGreenFlag"],
-            ["doRepeat", 100, [["wait:elapsed:from:", ["timer"]], ["timerReset"]]]]
-        ]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ["doRepeat", 100, [
-                ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
-                ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]]
-        ]]]
-
-        # create project
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 2
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_scripts_data[0])
-        assert script == expected_script
-        script = background_object.scripts[1]
-        expected_script = scratch.Script(expected_background_object_scripts_data[1])
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-    def test_reset_timer_block_with_existant_timer_block_in_other_object_must_NOT_be_ignored(self):
-        cls = self.__class__
-        background_script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [background_script_data]
-        expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
-            ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
-        ]], [0, 0, [['whenGreenFlag'],
-            ['doForever', [
-                ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
-                ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]]
-        ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
-            ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
-        ]]]
-
-        # first object scripts
-        first_object_script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
-        cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [first_object_script_data]
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
-            ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
-        ]]
-
-        # create project
-        raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 3
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_scripts_data[0])
-        assert script == expected_script
-        script = background_object.scripts[1]
-        expected_script = scratch.Script(expected_background_object_scripts_data[1])
-        assert script == expected_script
-        script = background_object.scripts[2]
-        expected_script = scratch.Script(expected_background_object_scripts_data[2])
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
-
-class TestBackdropWorkaround(unittest.TestCase):
-    BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [{'baseLayerMD5': ''}, {'baseLayerMD5': ''}, {'baseLayerMD5': ''}],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "scripts": [],
-        "children": [{ "objName": "Sprite1", "scripts": [] }],
-        "info": {}
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-
-    def _setup_objects(self, blocks, backdrop_script = [], multiple_sprites = 1):
-        cls = self.__class__
-        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = [{ "objName": "Sprite1", "scripts": [] }]
-        input_script = [0, 0, [["whenGreenFlag"]]]
-        expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
-
-        # parse backdrop input and output
-        if backdrop_script:
-            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
-            backdrop_script = [backdrop_script]
-
-        # validate backgrounds
-        assert len(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["costumes"]) == 3
-
-        # initialize backdrop scripts
-        for block in set(blocks):
-            if "random" not in block:
-                backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", block]]])
-            else:
-                backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", ['randomFrom:to:', 1.0, 3.0]]]])
-
-        # parse input and expected output
-        for i in range(4):
-            for block in blocks:
-                input_script[2].extend([["startScene", block],["wait:elapsed:from:", 1]])
-                expected_sprite_script[2].extend([["broadcast:", block], ["wait:elapsed:from:", 1]])
-
-        # multiple sprites?
-        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [input_script]
-        if multiple_sprites == 2:
-            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": []})
-            cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [input_script]
-
-        # prepare values for return
-        expected_sprite_script = scratch.Script(expected_sprite_script)
-        expected_backdrop = []
-        for script in backdrop_script:
-            expected_backdrop.append(scratch.Script(script))
-        raw_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
-        return {"converted": raw_project, "expected": {"Backdrop": expected_backdrop, "Sprite": [expected_sprite_script]}}
-
-    def test_previous_backdrop_in_single_sprite(self):
-        test_data = self._setup_objects(["previous backdrop"], [])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_multiple_sprites(self):
-        test_data = self._setup_objects(["previous backdrop"], [], 2)
-
-        assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
-        assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-        assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-        assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_multiple_backdrop_scripts_single_sprite(self):
-        test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_multiple_backdrop_scripts_multiple_sprites(self):
-        test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
-
-        assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
-        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-        assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-        assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
-
-    def test_random_backdrop_in_stage(self):
-        cls = self.__class__
-        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
-        cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [[0,0,[['whenGreenFlag'], ['startScene', 'random backdrop']]]]
-        expected = scratch.Script([0,0,[['whenGreenFlag'], ['startScene', ['randomFrom:to:', 1.0, 3.0]]]])
-        converted_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
-
-        assert len(converted_project.objects) == 1
-        assert len(converted_project.objects[0].scripts) == 1
-
-        assert converted_project.objects[0].scripts[0] == expected
-
-    def test_next_backdrop_and_previous_backdrop_in_single_sprite(self):
-        test_data = self._setup_objects(["next backdrop", "previous backdrop"], [])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_next_backdrop_and_random_backdrop_in_single_sprite(self):
-        test_data = self._setup_objects(["next backdrop", "random backdrop"], [])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_and_random_backdrop_in_single_sprite(self):
-        test_data = self._setup_objects(["previous backdrop", "random backdrop"], [])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_next_backdrop_and_random_backdrop_in_single_sprite(self):
-        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"], [])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 3 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_single_sprite(self):
-        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
-                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-    def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_multiple_sprites(self):
-        test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
-                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
-
-        assert len(test_data["converted"].objects) == 3
-        assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
-        assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
-
-        assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
-        assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
-
-class TestKeyPressedWorkaround(unittest.TestCase):
-    KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [{ "objName": "Sprite1", "scripts": None }],
-        "info": {}
-    }
-
-    KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE = {
-        "doIf": [['doIf', ['keyPressed:', None], None]],
-        "doIfElse": [['doIfElse', ['keyPressed:', None], None, None]],
-        "doUntil": [['doUntil', ['keyPressed:', None], None]],
-        "doWaitUntil": [['doWaitUntil', ['keyPressed:', None]]]
-    }
-
-    KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS = {
-        "or": [['|', ['keyPressed:', None], ['keyPressed:', None]]],
-        "and": [['&', ['keyPressed:', None], ['keyPressed:', None]]],
-        "not": ['not', ['keyPressed:', None]]
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
-
-    def _setup_objects(self, blocks, keys, backdrop_script = [], multiple_sprites = 1, operator = None):
-        cls = self.__class__
-        input_script = [0, 0, [["whenGreenFlag"]]]
-        expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
-
-        if operator is not None:
-            assert len(keys) > 1
-
-        if backdrop_script:
-            cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
-
-        for block in set(blocks):
-            input_script[2].extend(cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block])
-            script_after = cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block]
-            script_after[0][1][0] = "readVariable"
-            script_after[0][1][1] = "S2CC:key_" + str(keys[0])
-            expected_sprite_script[2].extend(script_after)
-
-        if len(set(blocks)) > 1 and (operator == "or" or operator == "and"):
-            operator_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS.get(operator)
-            operator_brick[0][1][1] = str(keys[0])
-            operator_brick[0][2][1] = str(keys[1])
-            input_script[2].extend(operator_brick)
-            for x in [1,2]:
-                for y in [0,1]:
-                    operator_brick[0][x][y] = ("S2CC:key_" + str(keys[x-1])
-                                               if operator_brick[0][x][y] in keys
-                                               else "readVariable")
-            expected_sprite_script[2].extend(operator_brick)
-        elif operator == "not":
-            not_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS["not"]
-            not_brick[1][1] = keys[0]
-            input_script[2].extend(not_brick)
-            not_brick[1][0] = "readVariable"
-            not_brick[1][1] = "S2CC:key_" + str(keys[0])
-            expected_sprite_script[2].extend(not_brick)
-
-        for index in range(multiple_sprites):
-            cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite" + str(index+1), "scripts": [input_script]})
-
-        expected_sprite_script = scratch.Script(expected_sprite_script)
-        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-        return {"converted": raw_project, "expected_sprite": [expected_sprite_script]}
-
-    def test_key_pressed_do_if_block_up_arrow_key(self):
-        test_data = self._setup_objects(["doIf"], ["up arrow"])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_if_else_block_space_key(self):
-        test_data = self._setup_objects(["doIfElse"], ["space"])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_until_block_down_arrow_key(self):
-        test_data = self._setup_objects(["doUntil"], ["down arrow"])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_wait_until_block_any_key(self):
-        test_data = self._setup_objects(["doWaitUntil"], ["any"])
-
-        assert len(test_data["converted"].objects) == 2
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_if_and_do_if_else_blocks_i_key_multiple_sprites(self):
-        test_data = self._setup_objects(["doIf", "doIfElse"], ["i"], [], 3)
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_until_and_do_wait_until_blocks_n_key_multiple_sprites(self):
-        test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space"], [], 3)
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_wait_until_block_any_key_backdrop_script_multiple_sprites(self):
-        test_data = self._setup_objects(["doWaitUntil"], ["any"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3)
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 1
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_until_and_do_wait_until_blocks_space_and_i_keys_multiple_sprites_and_and_block(self):
-        test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space", "i"], [], 3, "and")
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_if_and_do_if_else_blocks_any_and_up_arrow_keys_multiple_sprites_and_or_block(self):
-        test_data = self._setup_objects(["doIf", "doIfElse"], ["any", "up arrow"], [], 3, "or")
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 0
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed_do_until_do_wait_until_do_if_and_do_if_else_blocks_right_arrow_and_y_keys_backdrop_script_multiple_sprites_and_not_block(self):
-        test_data = self._setup_objects(["doUntil", "doWaitUntil", "doIf", "doIfElse"], ["right arrow", "y"],
-                                        [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3, "not")
-
-        assert len(test_data["converted"].objects) == 4
-        assert len(test_data["converted"].objects[0].scripts) == 1
-        assert len(test_data["converted"].objects[1].scripts) == 1
-
-        assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
-
-    def test_key_pressed(self):
-        cls = self.__class__
-        script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["keyPressed:", "w"],[["changeYposBy:", 1]]]]]]]
-        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
-        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-        key_pressed_var_name = scratch.S2CC_KEY_VARIABLE_NAME + "w"
-        expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["readVariable", key_pressed_var_name],[["changeYposBy:", 1]]]]]]]
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, sprite_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        script = sprite_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-    def test_key_pressed_with_formula(self):
-        cls = self.__class__
-        script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", [u'keyPressed:', [u'+', 3.0, 2.0]],[["changeYposBy:", 1]]]]]]]
-        cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
-        raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
-        expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever",
-                                                                    [["doIf", ["=", "space", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_space"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "up arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_up arrow"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "down arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_down arrow"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "left arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_left arrow"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "right arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_right arrow"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "1", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_1"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "2", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_2"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "3", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_3"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "4", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_4"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "5", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_5"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "6", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_6"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "7", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_7"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "8", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_8"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "9", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_9"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "0", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_0"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "q", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_q"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "w", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_w"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "e", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_e"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "r", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_r"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "t", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_t"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "z", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_z"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "u", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_u"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "i", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_i"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "o", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_o"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "p", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_p"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "a", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_a"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "s", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_s"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "d", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_d"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "f", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_f"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "g", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_g"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "h", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_h"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "j", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_j"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "k", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_k"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "l", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_l"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "y", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_y"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "x", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_x"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "c", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_c"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "v", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_v"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "b", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_b"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "n", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_n"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "m", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_m"], [["changeYposBy:", 1]]]]],
-                                                                     ["doIf", ["=", "any", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_any"], [["changeYposBy:", 1]]]]]]]]]
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, sprite_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        script = sprite_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-class TestDistanceBlockWorkaround(unittest.TestCase):
-    DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [{ "objName": "Sprite1", "scripts": None },
-                     { "objName": "Sprite2", "scripts": None }],
-        "info": {}
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-
-    def test_single_distance_block(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-              ]
-            ]]
-        ]]]
-        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-            ["doForever", [
-              ["setVar:to:", position_x_var_name, ["xpos"]],
-              ["setVar:to:", position_y_var_name, ["ypos"]],
-              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 1
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 2
-        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-
-    def test_two_distance_blocks_in_same_object(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]],
-                              ["forward:", ["distanceTo:", "Sprite2"]]]]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-              ]
-            ]]
-        ], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-              ]
-            ]]
-        ]]]
-        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-            ["doForever", [
-              ["setVar:to:", position_x_var_name, ["xpos"]],
-              ["setVar:to:", position_y_var_name, ["ypos"]],
-              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 1
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 2
-        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-
-    def test_two_distance_blocks_in_different_objects(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-        expected_background_and_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-              ]
-            ]]
-        ]]]
-        expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
-            ["doForever", [
-              ["setVar:to:", position_x_var_name, ["xpos"]],
-              ["setVar:to:", position_y_var_name, ["ypos"]],
-              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 1
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_and_first_object_script_data)
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_background_and_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 1
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 2
-        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-
-    def test_two_different_distance_blocks_in_different_objects(self):
-        cls = self.__class__
-        script_data0 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
-        script_data2 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite1"]]]]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data0]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = []
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [script_data2]
-        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-        position_x_var_name1 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite1"
-        position_y_var_name1 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite1"
-        position_x_var_name2 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
-        position_y_var_name2 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
-        expected_background_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]]
-              ]
-            ]]
-        ]]]
-        expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-            ["doForever", [
-              ["setVar:to:", position_x_var_name1, ["xpos"]],
-              ["setVar:to:", position_y_var_name1, ["ypos"]],
-              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]
-        expected_second_object_scripts_data = [[0, 0, [["whenGreenFlag"], ['forward:',
-            ["computeFunction:of:", "sqrt", ["+",
-              ["*",
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]],
-                ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]]
-              ], ["*",
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]],
-                ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]]
-              ]
-            ]]
-        ]]], [0, 0, [['whenGreenFlag'],
-            ["doForever", [
-              ["setVar:to:", position_x_var_name2, ["xpos"]],
-              ["setVar:to:", position_y_var_name2, ["ypos"]],
-              ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-            ]]
-        ]]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 1
-        script = background_object.scripts[0]
-        expected_script = scratch.Script(expected_background_object_script_data)
-        assert script == expected_script
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 2
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_scripts_data[0])
-        assert script == expected_script
-        script = second_object.scripts[1]
-        expected_script = scratch.Script(expected_second_object_scripts_data[1])
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 4
-        assert global_variables[0] == { "name": position_x_var_name2, "value": 0, "isPersistent": False }
-        assert global_variables[1] == { "name": position_y_var_name2, "value": 0, "isPersistent": False }
-        assert global_variables[2] == { "name": position_x_var_name1, "value": 0, "isPersistent": False }
-        assert global_variables[3] == { "name": position_y_var_name1, "value": 0, "isPersistent": False }
-
-    def test_single_distance_block_to_mouse_pointer(self):
-        cls = self.__class__
-        script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "_mouse_"]]]]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "_mouse_"
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "_mouse_"
-        expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ["forward:",
-            ["computeFunction:of:", "sqrt",
-                ["+",
-                    ["*",
-                        ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
-                        ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
-                    ],
-                    ["*",
-                        ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
-                        ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
-                    ]
-                 ]]
-            ]]]
-
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # mouse-sprite will be created during conversion and not in the pre-processing ->
-        # for now, the second sprite is irrelevant
-        assert len(second_object.scripts) == 0
-
-        # global variables; for the mouse-pointer workaround, the variables are created during conversion
-        # and not in the pre-process
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 0
-
-        # check the flag -> indicates that mouse-sprite has to be created during conversion
-        assert raw_project._has_mouse_position_script
-
-class TestGlideToObjectBlockWorkaround(unittest.TestCase):
-    GLIDE_TO_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [{ "objName": "Sprite1", "scripts": None },
-                     { "objName": "Sprite2", "scripts": None }],
-        "info": {}
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["scripts"] = []
-
-    def test_glide_to_different_sprite(self):
-        cls = self.__class__
-        spinner_selection = "Sprite2"
-        time_in_sec = "1"
-        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
-        expected_first_object_script_data = \
-            [0, 0, [["whenGreenFlag"], [
-                "glideSecs:toX:y:elapsed:from:",
-                 time_in_sec,
-                ["readVariable", position_x_var_name],
-                ["readVariable", position_y_var_name]
-            ]]]
-
-        expected_second_object_script_data = \
-            [0, 0, [["whenGreenFlag"],[
-                    "doForever", [
-                        ["setVar:to:", position_x_var_name, ["xpos"]],
-                        ["setVar:to:", position_y_var_name, ["ypos"]],
-                        ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                 ]]
-            ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 1
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_script_data)
-        assert script == expected_script
-
-        # global variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 2
-        assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
-        assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
-
-    def test_glide_to_random_position(self):
-        cls = self.__class__
-        spinner_selection = "_random_"
-        time_in_sec = "1"
-        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-
-        # random position also needs a workaround -> different resolutions in scratch and pocket code
-        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-
-        expected_first_object_script_data = \
-            [0, 0, [["whenGreenFlag"],[
-                "glideSecs:toX:y:elapsed:from:",
-                time_in_sec,
-                ["randomFrom:to:", left_x, right_x],
-                ["randomFrom:to:", lower_y, upper_y]
-            ]]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 0
-
-    def test_glide_to_mouse_poointer(self):
-        cls = self.__class__
-        spinner_selection = "_mouse_"
-        time_in_sec = "1"
-        script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
-        expected_first_object_script_data = \
-            [0, 0, [["whenGreenFlag"], [
-                "glideSecs:toX:y:elapsed:from:",
-                time_in_sec,
-                ["readVariable", position_x_var_name],
-                ["readVariable", position_y_var_name]
-            ]]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # same as in the 'distanceTo'-block workaround, the mouse-sprite is created during
-        # conversion and not in the pre-processing -> no mouse-sprite yet
-        assert len(second_object.scripts) == 0
-
-        # global variables; for the mouse-pointer workaround, the variables are created during conversion
-        # and not in the pre-process
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 0
-
-        # check the flag -> indicates that mouse-sprite has to be created during conversion
-        assert raw_project._has_mouse_position_script
-
-    def test_glide_to_random_single_nested(self):
-        cls = self.__class__
-        spinner_selection = "_random_"
-        time_in_sec = "1"
-        script_data = [0, 0, [["whenGreenFlag"], ["doForever", ["glideTo:", time_in_sec, spinner_selection]]]]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-
-        # random position also needs a workaround -> different resolutions in scratch and pocket code
-        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-
-        expected_first_object_script_data = \
-            [0, 0, [["whenGreenFlag"],
-                ["doForever",
-                    ["glideSecs:toX:y:elapsed:from:",
-                        time_in_sec,
-                        ["randomFrom:to:", left_x, right_x],
-                        ["randomFrom:to:", lower_y, upper_y]
-                    ]
-                ]
-            ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 0
-
-    def test_glide_to_objects_double_nested(self):
-        cls = self.__class__
-        spinner_selection_random = "_random_"
-        spinner_selection_mouse = "_mouse_"
-        time_in_sec = "1"
-
-        script_data = [0, 0, [["whenGreenFlag"],
-                                ["doForever",
-                                    ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
-                                        ["glideTo:", time_in_sec, spinner_selection_random],
-                                        ["glideTo:", time_in_sec, spinner_selection_mouse]
-                                    ]
-                                ]
-                            ]]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
-        cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
-        raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
-
-        # variables for x and y positions of the mouse-pointer
-        position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection_mouse
-        position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection_mouse
-
-        # random position option also needs a workaround -> different resolutions in scratch and pocket code
-        left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
-        lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
-
-        expected_first_object_script_data = \
-            [0, 0, [["whenGreenFlag"],
-                    ["doForever",
-                        ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
-                            ["glideSecs:toX:y:elapsed:from:",
-                                time_in_sec,
-                                ["randomFrom:to:", left_x, right_x],
-                                ["randomFrom:to:", lower_y, upper_y]
-                            ],
-                            ["glideSecs:toX:y:elapsed:from:",
-                                time_in_sec,
-                                ["readVariable", position_x_var_name],
-                                ["readVariable", position_y_var_name]
-                            ]
-                        ]
-                    ]
-            ]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # background object
-        assert len(background_object.scripts) == 0
-
-        # first object
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_script_data)
-        assert script == expected_script
-
-        # second object
-        assert len(second_object.scripts) == 0
-
-
-class TestShowSensorBlockWorkarounds(unittest.TestCase):
-    SENSOR_HELPER_OBJECTS_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [{ "objName": "Sprite1", "scripts": [] }],
-        "info": {}
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
-        self.original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"][:]
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-        cls = self.__class__
-        cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = self.original_child_objects[:]
-
-    def test_convert_show_sensor_without_parameter_block(self):
-        cls = self.__class__
-        sprite_name = "Sprite1"
-        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-        for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-                "target": sprite_name,
-                "cmd": command_name,
-                "param": None,
-                "visible": True
-            }]
-
-            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
-            expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [command_name]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 0
-            assert len(first_object.scripts) == 1
-            script = first_object.scripts[0]
-            expected_script = scratch.Script(expected_first_object_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(background_object._dict_object["variables"]) == 0
-            first_object_variables = first_object._dict_object["variables"]
-            assert len(first_object_variables) == 1
-            assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_show_sensor_with_parameter_block(self):
-        cls = self.__class__
-        sprite_name = "Sprite1"
-        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-        for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-                "target": sprite_name,
-                "cmd": command_name,
-                "param": param,
-                "visible": True
-            }]
-
-            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
-            expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [command_name, param]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 0
-            assert len(first_object.scripts) == 1
-            script = first_object.scripts[0]
-            expected_script = scratch.Script(expected_first_object_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(background_object._dict_object["variables"]) == 0
-            first_object_variables = first_object._dict_object["variables"]
-            assert len(first_object_variables) == 1
-            assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_stage_specific_show_sensor_without_parameter_block(self):
-        cls = self.__class__
-        sprite_name = "Stage"
-        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-        for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-                "target": sprite_name,
-                "cmd": command_name,
-                "param": None,
-                "visible": True
-            }]
-
-            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
-            expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [command_name]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(first_object.scripts) == 0
-            assert len(background_object.scripts) == 1
-            script = background_object.scripts[0]
-            expected_script = scratch.Script(expected_stage_object_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(first_object._dict_object["variables"]) == 0
-            stage_object_variables = background_object._dict_object["variables"]
-            assert len(stage_object_variables) == 1
-            assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_stage_specific_show_sensor_with_parameter_block(self):
-        cls = self.__class__
-        sprite_name = "Stage"
-        original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
-        for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
-            cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
-                "target": sprite_name,
-                "cmd": command_name,
-                "param": param,
-                "visible": True
-            }]
-
-            raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
-            variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
-            expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [command_name, param]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(first_object.scripts) == 0
-            assert len(background_object.scripts) == 1
-            script = background_object.scripts[0]
-            expected_script = scratch.Script(expected_stage_object_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(first_object._dict_object["variables"]) == 0
-            stage_object_variables = background_object._dict_object["variables"]
-            assert len(stage_object_variables) == 1
-            assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-
-class TestGetAttributeBlockWorkarounds(unittest.TestCase):
-
-    ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP = {
-        "x position": "xpos",
-        "y position": "ypos",
-        "direction": "heading",
-        "costume #": "costumeIndex",
-        "costume name": "costumeName",
-        "size": "scale",
-        "volume": "volume"
-    }
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-        cls = self.__class__
-        self.root_info = {
-            "objName": "Stage",
-            "sounds": [],
-            "costumes": [],
-            "currentCostumeIndex": 0,
-            "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-            "penLayerID": 0,
-            "tempoBPM": 60,
-            "videoAlpha": 0.5,
-            "children": [{ "objName": "Sprite1", "scripts": [] }],
-            "scripts": [],
-            "variables": [{ "name": "result", "value": 1, "isPersistent": False }],
-            "info": {}
-        }
-
-    def test_convert_global_variable_attribute_block(self):
-        cls = self.__class__
-        variable_name = "result"
-        first_script_data = [0, 0, [["whenGreenFlag"],
-            ["wait:elapsed:from:", 2],
-            ["setVar:to:", "result", ["getAttribute:of:", variable_name, "_stage_"]]
-        ]]
-        self.root_info["children"][0]["scripts"] = [first_script_data]
-        raw_project = scratch.RawProject(self.root_info)
-        first_script_data[2][2][2] = ["readVariable", variable_name]
-        expected_first_object_first_script_data = first_script_data
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # scripts of sprite objects
-        assert len(background_object.scripts) == 0
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_first_script_data)
-        assert script == expected_script
-
-        # sprite variables
-        global_variables = background_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert len(first_object._dict_object["variables"]) == 0
-        assert global_variables[0] == { "name": variable_name, "value": 1, "isPersistent": False }
-
-    def test_convert_local_variable_of_same_object_attribute_block(self):
-        cls = self.__class__
-        sprite_name = "Sprite1"
-        variable_name = "localVariable"
-        first_script_data = [0, 0, [["whenGreenFlag"],
-            ["wait:elapsed:from:", 2],
-            ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name]]
-        ]]
-        self.root_info["children"][0]["scripts"] = [first_script_data]
-        self.root_info["children"][0]["variables"] = [{ "name": variable_name, "value": 0, "isPersistent": False }]
-        raw_project = scratch.RawProject(self.root_info)
-        first_script_data[2][2][2] = ["readVariable", variable_name]
-        expected_first_object_first_script_data = first_script_data
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # scripts of sprite objects
-        assert len(background_object.scripts) == 0
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_first_script_data)
-        assert script == expected_script
-
-        # sprite variables
-        global_variables = background_object._dict_object["variables"]
-        first_object_variables = first_object._dict_object["variables"]
-        assert len(global_variables) == 1
-        assert len(first_object_variables) == 1
-        assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-        assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_local_variable_of_other_object_attribute_block(self):
-        cls = self.__class__
-        sprite_name_of_other_object = "Sprite2"
-        variable_name = "localVariableOfSprite2"
-        self.root_info["children"] += [{
-            "objName": sprite_name_of_other_object,
-            "scripts": [],
-            "variables": [{ "name": variable_name, "value": 0, "isPersistent": False }]
-        }]
-        first_script_data = [0, 0, [["whenGreenFlag"],
-            ["wait:elapsed:from:", 2],
-            ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name_of_other_object]]
-        ]]
-        self.root_info["children"][0]["scripts"] = [first_script_data]
-        raw_project = scratch.RawProject(self.root_info)
-        helper_variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_readVariable:{}".format(sprite_name_of_other_object, variable_name)
-        first_script_data[2][2][2] = ["readVariable", helper_variable_name]
-        expected_first_object_first_script_data = first_script_data
-        expected_second_object_first_script_data = [0, 0, [["whenGreenFlag"], ["doForever", [
-            ["setVar:to:", helper_variable_name, ["readVariable", variable_name]],
-            ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-        ]]]]
-
-        # validate
-        assert len(raw_project.objects) == 3
-        [background_object, first_object, second_object] = raw_project.objects
-
-        # scripts of sprite objects
-        assert len(background_object.scripts) == 0
-        assert len(first_object.scripts) == 1
-        assert len(second_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_first_script_data)
-        assert script == expected_script
-        script = second_object.scripts[0]
-        expected_script = scratch.Script(expected_second_object_first_script_data)
-        assert script == expected_script
-
-        # sprite variables
-        global_variables = background_object._dict_object["variables"]
-        second_object_variables = second_object._dict_object["variables"]
-        assert len(global_variables) == 2
-        assert len(first_object._dict_object["variables"]) == 0
-        assert len(second_object_variables) == 1
-        assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-        assert global_variables[1] == { "name": helper_variable_name, "value": 0, "isPersistent": False }
-        assert second_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_background_specific_attributes_of_same_object_block(self):
-        cls = self.__class__
-        stage_name = "Stage"
-        for attribute_name, sensor_name in [("backdrop #", "backgroundIndex"), ("backdrop name", "sceneName")]:
-            first_script_data = [0, 0, [["whenGreenFlag"],
-                ["wait:elapsed:from:", 2],
-                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, stage_name]]
-            ]]
-            self.root_info["scripts"] = [first_script_data]
-            raw_project = scratch.RawProject(self.root_info)
-            first_script_data[2][2][2] = [sensor_name]
-            expected_stage_object_first_script_data = first_script_data
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 1
-            assert len(first_object.scripts) == 0
-            script = background_object.scripts[0]
-            expected_script = scratch.Script(expected_stage_object_first_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(background_object._dict_object["variables"]) == 1
-            assert len(first_object._dict_object["variables"]) == 0
-
-    def test_convert_attribute_of_same_object_block(self):
-        cls = self.__class__
-        sprite_name = "Sprite1"
-        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-            first_script_data = [0, 0, [["whenGreenFlag"],
-                ["wait:elapsed:from:", 2],
-                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, sprite_name]]
-            ]]
-            self.root_info["children"][0]["scripts"] = [first_script_data]
-            raw_project = scratch.RawProject(self.root_info)
-            first_script_data[2][2][2] = [sensor_name]
-            expected_first_object_first_script_data = first_script_data
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 0
-            assert len(first_object.scripts) == 1
-            script = first_object.scripts[0]
-            expected_script = scratch.Script(expected_first_object_first_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            assert len(background_object._dict_object["variables"]) == 1
-            assert len(first_object._dict_object["variables"]) == 0
-
-    def test_should_convert_attribute_with_formula_block_to_zero_placeholder(self):
-        cls = self.__class__
-        first_script_data = [0, 0, [["whenGreenFlag"],
-            ["wait:elapsed:from:", 2],
-            ["setVar:to:", "result", ["getAttribute:of:", "x position", ["+", 1, 2]]]
-        ]]
-        self.root_info["children"][0]["scripts"] = [first_script_data]
-        raw_project = scratch.RawProject(self.root_info)
-        first_script_data[2][2][2] = 0
-        expected_first_object_first_script_data = first_script_data
-
-        # validate
-        assert len(raw_project.objects) == 2
-        [background_object, first_object] = raw_project.objects
-
-        # scripts of sprite objects
-        assert len(background_object.scripts) == 0
-        assert len(first_object.scripts) == 1
-        script = first_object.scripts[0]
-        expected_script = scratch.Script(expected_first_object_first_script_data)
-        assert script == expected_script
-
-        # sprite variables
-        assert len(background_object._dict_object["variables"]) == 1
-        assert len(first_object._dict_object["variables"]) == 0
-
-    def test_convert_attribute_of_other_object_block(self):
-        cls = self.__class__
-        other_object_name = "Stage"
-        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-            first_script_data = [0, 0, [["whenGreenFlag"],
-                ["wait:elapsed:from:", 2],
-                ["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]
-            ]]
-            self.root_info["children"][0]["scripts"] = [first_script_data]
-            raw_project = scratch.RawProject(self.root_info)
-            variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
-            expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [sensor_name]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-            first_script_data[2][2][2] = ["readVariable", variable_name]
-            expected_first_object_first_script_data = first_script_data
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 1
-            assert len(first_object.scripts) == 1
-            script = background_object.scripts[0]
-            expected_script = scratch.Script(expected_background_object_first_script_data)
-            assert script == expected_script
-            script = first_object.scripts[0]
-            expected_script = scratch.Script(expected_first_object_first_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            stage_object_variables = background_object._dict_object["variables"]
-            assert len(stage_object_variables) == 2
-            assert len(first_object._dict_object["variables"]) == 0
-            assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-            assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-    def test_convert_attribute_of_other_object_block_encapsulated(self):
-        cls = self.__class__
-        other_object_name = "Stage"
-        for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
-            first_script_data = [0, 0, [["whenGreenFlag"],
-                ["wait:elapsed:from:", 2],
-                ["doRepeat", 10,
-                    [["doIf", False, [["doIfElse", False,
-                        [["doForever",
-                            [["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]]
-                        ]], 0]]]
-                ]]
-            ]]
-            self.root_info["children"][0]["scripts"] = [first_script_data]
-            raw_project = scratch.RawProject(self.root_info)
-            variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
-            expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
-                ['doForever', [
-                    ["setVar:to:", variable_name, [sensor_name]],
-                    ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
-                ]]
-            ]]
-            first_script_data[2][2][2][0][2][0][2][0][1][0][2] = ["readVariable", variable_name]
-            expected_first_object_first_script_data = first_script_data
-
-            # validate
-            assert len(raw_project.objects) == 2
-            [background_object, first_object] = raw_project.objects
-
-            # scripts of sprite objects
-            assert len(background_object.scripts) == 1
-            assert len(first_object.scripts) == 1
-            script = background_object.scripts[0]
-            expected_script = scratch.Script(expected_background_object_first_script_data)
-            assert script == expected_script
-            script = first_object.scripts[0]
-            expected_script = scratch.Script(expected_first_object_first_script_data)
-            assert script == expected_script
-
-            # sprite variables
-            stage_object_variables = background_object._dict_object["variables"]
-            assert len(stage_object_variables) == 2
-            assert len(first_object._dict_object["variables"]) == 0
-            assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
-            assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
-
-
-class CommentWorkaround(unittest.TestCase):
-    COMMENT_DATA_TEMPLATE = {
-        "objName": "Stage",
-        "sounds": [],
-        "costumes": [],
-        "currentCostumeIndex": 0,
-        "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
-        "penLayerID": 0,
-        "tempoBPM": 60,
-        "videoAlpha": 0.5,
-        "children": [],
-        "info": {}
-    }
-
-    def get_stage(self, scripts, comments):
-        data = self.COMMENT_DATA_TEMPLATE
-        data["scriptComments"] = comments
-        data["scripts"] = scripts
-        raw_project = scratch.RawProject(data)
-        self.assertEqual(1, len(raw_project.objects))
-        return raw_project.objects[0]
-
-    @classmethod
-    def get_comment(cls, blockId, text):
-        return [0, 0, 0, 0, False, blockId, text]
-
-    def test_simple_comment(self):
-        for blockId in [-1, 0, 1]:
-            script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1]]]
-            comment = self.get_comment(1, "test_comment")
-            stage = self.get_stage([script], [comment])
-
-            self.assertEqual(1, len(stage.scripts))
-            script = stage.scripts[0]
-            self.assertListEqual([['note:', 'test_comment'], ['wait:elapsed:from:', 1]], script.blocks)
-
-    def test_condition_comment(self):
-        script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1], ["wait:elapsed:from:", ["+", 1, 2]], ["wait:elapsed:from:", 1]]]
-        comments = [self.get_comment(3, "condition_comment"), self.get_comment(4, "wait_comment")]
-        stage = self.get_stage([script], comments)
-
-        self.assertEqual(1, len(stage.scripts))
-        script = stage.scripts[0]
-        expected_blocks = [['wait:elapsed:from:', 1],
-                           ['note:', 'condition_comment'],
-                           ['wait:elapsed:from:', ['+', 1, 2]],
-                           ['note:', 'wait_comment'],
-                           ['wait:elapsed:from:', 1]]
-        self.assertListEqual(expected_blocks, script.blocks)
-
-    def test_comment_in_if(self):
-        script = [0, 0, [["whenGreenFlag"], ["doIf", [">", 5, 4], [["wait:elapsed:from:", 1]]], ["wait:elapsed:from:", 1]]]
-        comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "after_if_comment")]
-        stage = self.get_stage([script], comments)
-
-        self.assertEqual(1, len(stage.scripts))
-        script = stage.scripts[0]
-        expected_blocks = [['doIf',
-                            ['>', 5, 4],
-                            [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]]],
-                           ['note:', 'after_if_comment'],
-                           ['wait:elapsed:from:', 1]]
-        self.assertListEqual(expected_blocks, script.blocks)
-
-    def test_comment_in_else(self):
-        script = [0, 0, [["whenGreenFlag"], ["doIfElse", [">", 5, 4], [["wait:elapsed:from:", 1]], [["wait:elapsed:from:", 2]]], ["wait:elapsed:from:", 1]]]
-        comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "in_else_comment"), self.get_comment(5, "after_if_comment")]
-        stage = self.get_stage([script], comments)
-
-        self.assertEqual(1, len(stage.scripts))
-        script = stage.scripts[0]
-        expected_blocks = [['doIfElse',
-                            ['>', 5, 4],
-                            [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]],
-                            [['note:', 'in_else_comment'], ['wait:elapsed:from:', 2]]],
-                           ['note:', 'after_if_comment'],
-                           ['wait:elapsed:from:', 1]]
-        self.assertListEqual(expected_blocks, script.blocks)
-
-    def test_multiple_comments_same_brick(self):
-        NUM_COMMENTS = 20
-        for blockId in [-1, 0, 1, 2]:
-            script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
-            comments = [self.get_comment(1, "test_comment_{}".format(i)) for i in range(NUM_COMMENTS)]
-            stage = self.get_stage([script], comments)
-
-            self.assertEqual(1, len(stage.scripts))
-            script = stage.scripts[0]
-            expected_blocks = [["note:", "test_comment_{}".format(i)] for i in range(NUM_COMMENTS)][::-1] + [["wait:elapsed:from:", ["+", 1, 2]]]
-            self.assertListEqual(expected_blocks, script.blocks)
-
-    def test_invalid_blocks(self):
-        scripts = [
-            [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]],
-            [0, 0, [["+", 4, 3]]],
-            [0, 0, [["wait:elapsed:from:", "-", 2, -1]]],
-            [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
-        ]
-        comments = [self.get_comment(i, "comment_{}".format(i)) for i in range(8)]
-        stage = self.get_stage(scripts, comments)
-
-        self.assertEqual(2, len(stage.scripts))
-        expected_blocks_0 = [['note:', 'comment_0'],
-                             ['note:', 'comment_1'],
-                             ['note:', 'comment_2'],
-                             ['wait:elapsed:from:', ['+', 1, 2]]]
-        self.assertListEqual(expected_blocks_0, stage.scripts[0].blocks)
-        expected_blocks_1 = [['note:', 'comment_5'],
-                             ['note:', 'comment_6'],
-                             ['note:', 'comment_7'],
-                             ['wait:elapsed:from:', ['+', 1, 2]]]
-        self.assertListEqual(expected_blocks_1, stage.scripts[1].blocks)
-
-    def test_general_comment_without_scripts(self):
-        comment = self.get_comment(-1, "general comment")
-        stage = self.get_stage([], [comment])
-        self.assertListEqual([], stage.scripts)
+#
+# class TestBlockInit(unittest.TestCase):
+#
+#     def test_can_construct_on_correct_input(self):
+#         expected_values = (
+#             (4, (2, 2, 2, 1)),
+#             (1, (2,)),
+#             (1, (2,)),
+#         )
+#         for script_input, [expected_length, expected_block_children_number] in zip(EASY_SCRIPTS, expected_values):
+#             assert len(scratch.Script(script_input).blocks) == expected_length
+#             blocks = scratch.ScriptElement.from_raw_script(script_input)
+#             assert isinstance(blocks, scratch.BlockList) and len(blocks.children) == expected_length
+#             nested_blocks = blocks.children
+#             assert all(isinstance(block, scratch.ScriptElement) for block in nested_blocks)
+#             assert [len(block.children) for block in nested_blocks] == list(expected_block_children_number)
+#
+#
+# class TestScriptElementTree(common_testing.BaseTestCase):
+#
+#     def test_verify_simple_formula_in_script_element_tree(self):
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]]
+#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["randomFrom:to:", -100, 100]]]
+#
+#         script = scratch.Script(script_data)
+#         assert script.type == scratch.SCRIPT_GREEN_FLAG
+#         assert len(script.arguments) == 0
+#         assert script.raw_script == expected_raw_script_data
+#         assert script.blocks == expected_raw_script_data[1:]
+#         assert isinstance(script.script_element, scratch.BlockList)
+#         assert script.script_element.name == '<LIST>'
+#         assert len(script.script_element.children) == 1
+#
+#         script_element_child = script.script_element.children[0]
+#         assert script_element_child.name == 'wait:elapsed:from:'
+#         assert len(script_element_child.children) == 1
+#
+#         script_element_child = script_element_child.children[0]
+#         assert script_element_child.name == 'randomFrom:to:'
+#         assert len(script_element_child.children) == 2
+#
+#         left_child = script_element_child.children[0]
+#         right_child = script_element_child.children[1]
+#         assert left_child.name == -100
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 100
+#         assert len(right_child.children) == 0
+#
+#     def test_verify_complex_formula_in_script_element_tree(self):
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+#                         0, ["randomFrom:to:", 0, 100]]]]]
+#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+#                         0, ["randomFrom:to:", 0, 100]]]]
+#
+#         script = scratch.Script(script_data)
+#         assert script.type == scratch.SCRIPT_GREEN_FLAG
+#         assert len(script.arguments) == 0
+#         assert script.raw_script == expected_raw_script_data
+#         assert script.blocks == expected_raw_script_data[1:]
+#         assert isinstance(script.script_element, scratch.BlockList)
+#         assert script.script_element.name == '<LIST>'
+#         assert len(script.script_element.children) == 1
+#
+#         script_element_child = script.script_element.children[0]
+#         assert script_element_child.name == 'wait:elapsed:from:'
+#         assert len(script_element_child.children) == 1
+#
+#         script_element_child = script_element_child.children[0]
+#         assert script_element_child.name == '+'
+#         assert len(script_element_child.children) == 2
+#
+#         left_child = script_element_child.children[0]
+#         right_child = script_element_child.children[1]
+#         assert left_child.name == 0
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 'randomFrom:to:'
+#         assert len(right_child.children) == 2
+#
+#         left_child = right_child.children[0]
+#         right_child = right_child.children[1]
+#         assert left_child.name == 0
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 100
+#         assert len(right_child.children) == 0
+#
+#     def test_verify_complex_script_element_tree(self):
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+#                         0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]]
+#         expected_raw_script_data = [["whenGreenFlag"], ["wait:elapsed:from:", ["+", \
+#                         0, ["randomFrom:to:", 0, 100]]], ['changeVar:by:', "temp", 0.1]]
+#
+#         script = scratch.Script(script_data)
+#         assert script.type == scratch.SCRIPT_GREEN_FLAG
+#         assert len(script.arguments) == 0
+#         assert script.raw_script == expected_raw_script_data
+#         assert script.blocks == expected_raw_script_data[1:]
+#         assert isinstance(script.script_element, scratch.BlockList)
+#         assert script.script_element.name == '<LIST>'
+#         assert len(script.script_element.children) == 2
+#
+#         script_element_child = script.script_element.children[0]
+#         assert script_element_child.name == 'wait:elapsed:from:'
+#         assert len(script_element_child.children) == 1
+#         script_element_child = script_element_child.children[0]
+#         assert script_element_child.name == '+'
+#         assert len(script_element_child.children) == 2
+#
+#         left_child = script_element_child.children[0]
+#         right_child = script_element_child.children[1]
+#         assert left_child.name == 0
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 'randomFrom:to:'
+#         assert len(right_child.children) == 2
+#
+#         left_child = right_child.children[0]
+#         right_child = right_child.children[1]
+#         assert left_child.name == 0
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 100
+#         assert len(right_child.children) == 0
+#
+#         script_element_child = script.script_element.children[1]
+#         assert script_element_child.name == 'changeVar:by:'
+#         assert len(script_element_child.children) == 2
+#
+#         left_child = script_element_child.children[0]
+#         right_child = script_element_child.children[1]
+#         assert left_child.name == 'temp'
+#         assert len(left_child.children) == 0
+#         assert right_child.name == 0.1
+#         assert len(right_child.children) == 0
+#
+#
+# class TestTimerAndResetTimerBlockWorkarounds(unittest.TestCase):
+#     TIMER_HELPER_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [{ "objName": "Sprite1", "scripts": None }],
+#         "info": {}
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#
+#     def test_timer_block(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#         expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+#         ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 1
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_script_data)
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+#     def test_same_timer_block_twice(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["wait:elapsed:from:", ["timer"]]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         expected_background_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+#         ]]
+#
+#         # create project
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 1
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_script_data)
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+#     def test_reset_timer_block_with_non_existant_timer_block_should_automatically_add_timer_script(self):
+#         cls = self.__class__
+#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]]
+#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+#         ]]]
+#         script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ['doBroadcastAndWait', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+#         ]]
+#
+#         # create project
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 2
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
+#         assert script == expected_script
+#         script = background_object.scripts[1]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+#     def test_reset_timer_block_with_existant_timer_block_in_same_object_must_NOT_be_ignored(self):
+#         cls = self.__class__
+#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]]
+#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+#         ]]]
+#         script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]], ["timerReset"]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+#             ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+#         ]]
+#
+#         # create project
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 2
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
+#         assert script == expected_script
+#         script = background_object.scripts[1]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+#     def test_reset_timer_block_and_timer_block_within_loop_must_NOT_be_ignored(self):
+#         cls = self.__class__
+#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]]
+#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+#         ]]]
+#         script_data = [0, 0, [["whenGreenFlag"],
+#             ["doRepeat", 100, [["wait:elapsed:from:", ["timer"]], ["timerReset"]]]]
+#         ]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ["doRepeat", 100, [
+#                 ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]],
+#                 ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]]
+#         ]]]
+#
+#         # create project
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 2
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
+#         assert script == expected_script
+#         script = background_object.scripts[1]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+#     def test_reset_timer_block_with_existant_timer_block_in_other_object_must_NOT_be_ignored(self):
+#         cls = self.__class__
+#         background_script_data = [0, 0, [["whenGreenFlag"], ["timerReset"]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [background_script_data]
+#         expected_background_object_scripts_data = [[0, 0, [['whenGreenFlag'],
+#             ["doBroadcastAndWait", scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE]
+#         ]], [0, 0, [['whenGreenFlag'],
+#             ['doForever', [
+#                 ['changeVar:by:', scratch.S2CC_TIMER_VARIABLE_NAME, scratch.UPDATE_HELPER_VARIABLE_TIMEOUT],
+#                 ['wait:elapsed:from:', scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]]
+#         ], [0, 0, [['whenIReceive', scratch.S2CC_TIMER_RESET_BROADCAST_MESSAGE],
+#             ['setVar:to:', scratch.S2CC_TIMER_VARIABLE_NAME, 0]
+#         ]]]
+#
+#         # first object scripts
+#         first_object_script_data = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["timer"]]]]
+#         cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [first_object_script_data]
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"],
+#             ['wait:elapsed:from:', ['readVariable', scratch.S2CC_TIMER_VARIABLE_NAME]]
+#         ]]
+#
+#         # create project
+#         raw_project = scratch.RawProject(cls.TIMER_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 3
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[0])
+#         assert script == expected_script
+#         script = background_object.scripts[1]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[1])
+#         assert script == expected_script
+#         script = background_object.scripts[2]
+#         expected_script = scratch.Script(expected_background_object_scripts_data[2])
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert global_variables[0] == { "name": scratch.S2CC_TIMER_VARIABLE_NAME, "value": 0, "isPersistent": False }
+#
+# class TestBackdropWorkaround(unittest.TestCase):
+#     BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [{'baseLayerMD5': ''}, {'baseLayerMD5': ''}, {'baseLayerMD5': ''}],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "scripts": [],
+#         "children": [{ "objName": "Sprite1", "scripts": [] }],
+#         "info": {}
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#
+#     def _setup_objects(self, blocks, backdrop_script = [], multiple_sprites = 1):
+#         cls = self.__class__
+#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = [{ "objName": "Sprite1", "scripts": [] }]
+#         input_script = [0, 0, [["whenGreenFlag"]]]
+#         expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
+#
+#         # parse backdrop input and output
+#         if backdrop_script:
+#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
+#             backdrop_script = [backdrop_script]
+#
+#         # validate backgrounds
+#         assert len(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["costumes"]) == 3
+#
+#         # initialize backdrop scripts
+#         for block in set(blocks):
+#             if "random" not in block:
+#                 backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", block]]])
+#             else:
+#                 backdrop_script.append([0, 0, [["whenIReceive", block], ["startScene", ['randomFrom:to:', 1.0, 3.0]]]])
+#
+#         # parse input and expected output
+#         for i in range(4):
+#             for block in blocks:
+#                 input_script[2].extend([["startScene", block],["wait:elapsed:from:", 1]])
+#                 expected_sprite_script[2].extend([["broadcast:", block], ["wait:elapsed:from:", 1]])
+#
+#         # multiple sprites?
+#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [input_script]
+#         if multiple_sprites == 2:
+#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": []})
+#             cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [input_script]
+#
+#         # prepare values for return
+#         expected_sprite_script = scratch.Script(expected_sprite_script)
+#         expected_backdrop = []
+#         for script in backdrop_script:
+#             expected_backdrop.append(scratch.Script(script))
+#         raw_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
+#         return {"converted": raw_project, "expected": {"Backdrop": expected_backdrop, "Sprite": [expected_sprite_script]}}
+#
+#     def test_previous_backdrop_in_single_sprite(self):
+#         test_data = self._setup_objects(["previous backdrop"], [])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_multiple_sprites(self):
+#         test_data = self._setup_objects(["previous backdrop"], [], 2)
+#
+#         assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
+#         assert len(test_data["converted"].objects[0].scripts) == 1 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#         assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#         assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_multiple_backdrop_scripts_single_sprite(self):
+#         test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_multiple_backdrop_scripts_multiple_sprites(self):
+#         test_data = self._setup_objects(["previous backdrop"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
+#
+#         assert len(test_data["converted"].objects) == 3 # stage, sprite1, sprite2
+#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#         assert len(test_data["converted"].objects[2].scripts) == 1 # sprite2
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#         assert test_data["converted"].objects[2].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_random_backdrop_in_stage(self):
+#         cls = self.__class__
+#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
+#         cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [[0,0,[['whenGreenFlag'], ['startScene', 'random backdrop']]]]
+#         expected = scratch.Script([0,0,[['whenGreenFlag'], ['startScene', ['randomFrom:to:', 1.0, 3.0]]]])
+#         converted_project = scratch.RawProject(cls.BACKDROP_HELPER_OBJECTS_DATA_TEMPLATE)
+#
+#         assert len(converted_project.objects) == 1
+#         assert len(converted_project.objects[0].scripts) == 1
+#
+#         assert converted_project.objects[0].scripts[0] == expected
+#
+#     def test_next_backdrop_and_previous_backdrop_in_single_sprite(self):
+#         test_data = self._setup_objects(["next backdrop", "previous backdrop"], [])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_next_backdrop_and_random_backdrop_in_single_sprite(self):
+#         test_data = self._setup_objects(["next backdrop", "random backdrop"], [])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_and_random_backdrop_in_single_sprite(self):
+#         test_data = self._setup_objects(["previous backdrop", "random backdrop"], [])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 2 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_next_backdrop_and_random_backdrop_in_single_sprite(self):
+#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"], [])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 3 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_single_sprite(self):
+#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
+#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+#     def test_previous_backdrop_next_backdrop_and_random_backdrop_multiple_backdrop_scripts_in_multiple_sprites(self):
+#         test_data = self._setup_objects(["previous backdrop", "next backdrop", "random backdrop"],
+#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 2)
+#
+#         assert len(test_data["converted"].objects) == 3
+#         assert len(test_data["converted"].objects[0].scripts) == 4 # stage sprite
+#         assert len(test_data["converted"].objects[1].scripts) == 1 # sprite1
+#
+#         assert test_data["converted"].objects[0].scripts == test_data["expected"]["Backdrop"]
+#         assert test_data["converted"].objects[1].scripts == test_data["expected"]["Sprite"]
+#
+# class TestKeyPressedWorkaround(unittest.TestCase):
+#     KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [{ "objName": "Sprite1", "scripts": None }],
+#         "info": {}
+#     }
+#
+#     KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE = {
+#         "doIf": [['doIf', ['keyPressed:', None], None]],
+#         "doIfElse": [['doIfElse', ['keyPressed:', None], None, None]],
+#         "doUntil": [['doUntil', ['keyPressed:', None], None]],
+#         "doWaitUntil": [['doWaitUntil', ['keyPressed:', None]]]
+#     }
+#
+#     KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS = {
+#         "or": [['|', ['keyPressed:', None], ['keyPressed:', None]]],
+#         "and": [['&', ['keyPressed:', None], ['keyPressed:', None]]],
+#         "not": ['not', ['keyPressed:', None]]
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"] = []
+#
+#     def _setup_objects(self, blocks, keys, backdrop_script = [], multiple_sprites = 1, operator = None):
+#         cls = self.__class__
+#         input_script = [0, 0, [["whenGreenFlag"]]]
+#         expected_sprite_script = [0, 0, [["whenGreenFlag"]]]
+#
+#         if operator is not None:
+#             assert len(keys) > 1
+#
+#         if backdrop_script:
+#             cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [backdrop_script]
+#
+#         for block in set(blocks):
+#             input_script[2].extend(cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block])
+#             script_after = cls.KEYPRESSED_POSSIBLE_BLOCKS_INPUT_TEMPLATE[block]
+#             script_after[0][1][0] = "readVariable"
+#             script_after[0][1][1] = "S2CC:key_" + str(keys[0])
+#             expected_sprite_script[2].extend(script_after)
+#
+#         if len(set(blocks)) > 1 and (operator == "or" or operator == "and"):
+#             operator_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS.get(operator)
+#             operator_brick[0][1][1] = str(keys[0])
+#             operator_brick[0][2][1] = str(keys[1])
+#             input_script[2].extend(operator_brick)
+#             for x in [1,2]:
+#                 for y in [0,1]:
+#                     operator_brick[0][x][y] = ("S2CC:key_" + str(keys[x-1])
+#                                                if operator_brick[0][x][y] in keys
+#                                                else "readVariable")
+#             expected_sprite_script[2].extend(operator_brick)
+#         elif operator == "not":
+#             not_brick = cls.KEYPRESSED_POSSIBLE_OPERATOR_BLOCKS["not"]
+#             not_brick[1][1] = keys[0]
+#             input_script[2].extend(not_brick)
+#             not_brick[1][0] = "readVariable"
+#             not_brick[1][1] = "S2CC:key_" + str(keys[0])
+#             expected_sprite_script[2].extend(not_brick)
+#
+#         for index in range(multiple_sprites):
+#             cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite" + str(index+1), "scripts": [input_script]})
+#
+#         expected_sprite_script = scratch.Script(expected_sprite_script)
+#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+#         return {"converted": raw_project, "expected_sprite": [expected_sprite_script]}
+#
+#     def test_key_pressed_do_if_block_up_arrow_key(self):
+#         test_data = self._setup_objects(["doIf"], ["up arrow"])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_if_else_block_space_key(self):
+#         test_data = self._setup_objects(["doIfElse"], ["space"])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_until_block_down_arrow_key(self):
+#         test_data = self._setup_objects(["doUntil"], ["down arrow"])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_wait_until_block_any_key(self):
+#         test_data = self._setup_objects(["doWaitUntil"], ["any"])
+#
+#         assert len(test_data["converted"].objects) == 2
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_if_and_do_if_else_blocks_i_key_multiple_sprites(self):
+#         test_data = self._setup_objects(["doIf", "doIfElse"], ["i"], [], 3)
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_until_and_do_wait_until_blocks_n_key_multiple_sprites(self):
+#         test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space"], [], 3)
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_wait_until_block_any_key_backdrop_script_multiple_sprites(self):
+#         test_data = self._setup_objects(["doWaitUntil"], ["any"], [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3)
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 1
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_until_and_do_wait_until_blocks_space_and_i_keys_multiple_sprites_and_and_block(self):
+#         test_data = self._setup_objects(["doUntil", "doWaitUntil"], ["space", "i"], [], 3, "and")
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_if_and_do_if_else_blocks_any_and_up_arrow_keys_multiple_sprites_and_or_block(self):
+#         test_data = self._setup_objects(["doIf", "doIfElse"], ["any", "up arrow"], [], 3, "or")
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 0
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed_do_until_do_wait_until_do_if_and_do_if_else_blocks_right_arrow_and_y_keys_backdrop_script_multiple_sprites_and_not_block(self):
+#         test_data = self._setup_objects(["doUntil", "doWaitUntil", "doIf", "doIfElse"], ["right arrow", "y"],
+#                                         [0, 0, [['whenGreenFlag'], ["wait:elapsed:from:", 1]]], 3, "not")
+#
+#         assert len(test_data["converted"].objects) == 4
+#         assert len(test_data["converted"].objects[0].scripts) == 1
+#         assert len(test_data["converted"].objects[1].scripts) == 1
+#
+#         assert test_data["converted"].objects[1].scripts[0].raw_script == test_data["expected_sprite"][0].raw_script
+#
+#     def test_key_pressed(self):
+#         cls = self.__class__
+#         script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["keyPressed:", "w"],[["changeYposBy:", 1]]]]]]]
+#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
+#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+#         key_pressed_var_name = scratch.S2CC_KEY_VARIABLE_NAME + "w"
+#         expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", ["readVariable", key_pressed_var_name],[["changeYposBy:", 1]]]]]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, sprite_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         script = sprite_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#     def test_key_pressed_with_formula(self):
+#         cls = self.__class__
+#         script_data = [0,0,[["whenGreenFlag"],["doForever", [["doIf", [u'keyPressed:', [u'+', 3.0, 2.0]],[["changeYposBy:", 1]]]]]]]
+#         cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE["children"].append({"objName": "Sprite1", "scripts": [script_data]})
+#         raw_project = scratch.RawProject(cls.KEYPRESSED_HELPER_OBJECTS_DATA_TEMPLATE)
+#         expected_first_object_script_data = [0,0,[["whenGreenFlag"],["doForever",
+#                                                                     [["doIf", ["=", "space", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_space"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "up arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_up arrow"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "down arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_down arrow"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "left arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_left arrow"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "right arrow", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_right arrow"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "1", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_1"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "2", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_2"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "3", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_3"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "4", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_4"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "5", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_5"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "6", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_6"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "7", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_7"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "8", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_8"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "9", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_9"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "0", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_0"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "q", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_q"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "w", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_w"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "e", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_e"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "r", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_r"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "t", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_t"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "z", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_z"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "u", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_u"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "i", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_i"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "o", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_o"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "p", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_p"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "a", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_a"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "s", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_s"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "d", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_d"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "f", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_f"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "g", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_g"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "h", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_h"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "j", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_j"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "k", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_k"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "l", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_l"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "y", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_y"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "x", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_x"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "c", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_c"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "v", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_v"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "b", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_b"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "n", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_n"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "m", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_m"], [["changeYposBy:", 1]]]]],
+#                                                                      ["doIf", ["=", "any", ["()", ["+", 3.0, 2.0]]], [["doIf", ["readVariable", "S2CC:key_any"], [["changeYposBy:", 1]]]]]]]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, sprite_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         script = sprite_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+# class TestDistanceBlockWorkaround(unittest.TestCase):
+#     DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [{ "objName": "Sprite1", "scripts": None },
+#                      { "objName": "Sprite2", "scripts": None }],
+#         "info": {}
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#
+#     def test_single_distance_block(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+#               ]
+#             ]]
+#         ]]]
+#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ["doForever", [
+#               ["setVar:to:", position_x_var_name, ["xpos"]],
+#               ["setVar:to:", position_y_var_name, ["ypos"]],
+#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 1
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 2
+#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+#
+#     def test_two_distance_blocks_in_same_object(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]],
+#                               ["forward:", ["distanceTo:", "Sprite2"]]]]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+#               ]
+#             ]]
+#         ], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+#               ]
+#             ]]
+#         ]]]
+#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ["doForever", [
+#               ["setVar:to:", position_x_var_name, ["xpos"]],
+#               ["setVar:to:", position_y_var_name, ["ypos"]],
+#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 1
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 2
+#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+#
+#     def test_two_distance_blocks_in_different_objects(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+#         expected_background_and_first_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+#               ]
+#             ]]
+#         ]]]
+#         expected_second_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ["doForever", [
+#               ["setVar:to:", position_x_var_name, ["xpos"]],
+#               ["setVar:to:", position_y_var_name, ["ypos"]],
+#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 1
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_and_first_object_script_data)
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_and_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 1
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 2
+#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+#
+#     def test_two_different_distance_blocks_in_different_objects(self):
+#         cls = self.__class__
+#         script_data0 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite2"]]]]
+#         script_data2 = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "Sprite1"]]]]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = [script_data0]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = []
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = [script_data2]
+#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+#         position_x_var_name1 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite1"
+#         position_y_var_name1 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite1"
+#         position_x_var_name2 = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "Sprite2"
+#         position_y_var_name2 = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "Sprite2"
+#         expected_background_object_script_data = [0, 0, [["whenGreenFlag"], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name2]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name2]]]
+#               ]
+#             ]]
+#         ]]]
+#         expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+#             ["doForever", [
+#               ["setVar:to:", position_x_var_name1, ["xpos"]],
+#               ["setVar:to:", position_y_var_name1, ["ypos"]],
+#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]
+#         expected_second_object_scripts_data = [[0, 0, [["whenGreenFlag"], ['forward:',
+#             ["computeFunction:of:", "sqrt", ["+",
+#               ["*",
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]],
+#                 ["()", ["-", ["xpos"], ["readVariable", position_x_var_name1]]]
+#               ], ["*",
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]],
+#                 ["()", ["-", ["ypos"], ["readVariable", position_y_var_name1]]]
+#               ]
+#             ]]
+#         ]]], [0, 0, [['whenGreenFlag'],
+#             ["doForever", [
+#               ["setVar:to:", position_x_var_name2, ["xpos"]],
+#               ["setVar:to:", position_y_var_name2, ["ypos"]],
+#               ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#             ]]
+#         ]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 1
+#         script = background_object.scripts[0]
+#         expected_script = scratch.Script(expected_background_object_script_data)
+#         assert script == expected_script
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 2
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_scripts_data[0])
+#         assert script == expected_script
+#         script = second_object.scripts[1]
+#         expected_script = scratch.Script(expected_second_object_scripts_data[1])
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 4
+#         assert global_variables[0] == { "name": position_x_var_name2, "value": 0, "isPersistent": False }
+#         assert global_variables[1] == { "name": position_y_var_name2, "value": 0, "isPersistent": False }
+#         assert global_variables[2] == { "name": position_x_var_name1, "value": 0, "isPersistent": False }
+#         assert global_variables[3] == { "name": position_y_var_name1, "value": 0, "isPersistent": False }
+#
+#     def test_single_distance_block_to_mouse_pointer(self):
+#         cls = self.__class__
+#         script_data = [0, 0, [["whenGreenFlag"], ["forward:", ["distanceTo:", "_mouse_"]]]]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.DISTANCE_HELPER_OBJECTS_DATA_TEMPLATE)
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + "_mouse_"
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + "_mouse_"
+#         expected_first_object_script_data = [0, 0, [["whenGreenFlag"], ["forward:",
+#             ["computeFunction:of:", "sqrt",
+#                 ["+",
+#                     ["*",
+#                         ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]],
+#                         ["()", ["-", ["xpos"], ["readVariable", position_x_var_name]]]
+#                     ],
+#                     ["*",
+#                         ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]],
+#                         ["()", ["-", ["ypos"], ["readVariable", position_y_var_name]]]
+#                     ]
+#                  ]]
+#             ]]]
+#
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # mouse-sprite will be created during conversion and not in the pre-processing ->
+#         # for now, the second sprite is irrelevant
+#         assert len(second_object.scripts) == 0
+#
+#         # global variables; for the mouse-pointer workaround, the variables are created during conversion
+#         # and not in the pre-process
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 0
+#
+#         # check the flag -> indicates that mouse-sprite has to be created during conversion
+#         assert raw_project._has_mouse_position_script
+#
+# class TestGlideToObjectBlockWorkaround(unittest.TestCase):
+#     GLIDE_TO_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [{ "objName": "Sprite1", "scripts": None },
+#                      { "objName": "Sprite2", "scripts": None }],
+#         "info": {}
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#
+#     def test_glide_to_different_sprite(self):
+#         cls = self.__class__
+#         spinner_selection = "Sprite2"
+#         time_in_sec = "1"
+#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+#
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
+#         expected_first_object_script_data = \
+#             [0, 0, [["whenGreenFlag"], [
+#                 "glideSecs:toX:y:elapsed:from:",
+#                  time_in_sec,
+#                 ["readVariable", position_x_var_name],
+#                 ["readVariable", position_y_var_name]
+#             ]]]
+#
+#         expected_second_object_script_data = \
+#             [0, 0, [["whenGreenFlag"],[
+#                     "doForever", [
+#                         ["setVar:to:", position_x_var_name, ["xpos"]],
+#                         ["setVar:to:", position_y_var_name, ["ypos"]],
+#                         ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                  ]]
+#             ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 1
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_script_data)
+#         assert script == expected_script
+#
+#         # global variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 2
+#         assert global_variables[0] == { "name": position_x_var_name, "value": 0, "isPersistent": False }
+#         assert global_variables[1] == { "name": position_y_var_name, "value": 0, "isPersistent": False }
+#
+#     def test_glide_to_random_position(self):
+#         cls = self.__class__
+#         spinner_selection = "_random_"
+#         time_in_sec = "1"
+#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+#
+#         # random position also needs a workaround -> different resolutions in scratch and pocket code
+#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+#
+#         expected_first_object_script_data = \
+#             [0, 0, [["whenGreenFlag"],[
+#                 "glideSecs:toX:y:elapsed:from:",
+#                 time_in_sec,
+#                 ["randomFrom:to:", left_x, right_x],
+#                 ["randomFrom:to:", lower_y, upper_y]
+#             ]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 0
+#
+#     def test_glide_to_mouse_poointer(self):
+#         cls = self.__class__
+#         spinner_selection = "_mouse_"
+#         time_in_sec = "1"
+#         script_data = [0, 0, [["whenGreenFlag"], ["glideTo:", time_in_sec, spinner_selection]]]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+#
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection
+#         expected_first_object_script_data = \
+#             [0, 0, [["whenGreenFlag"], [
+#                 "glideSecs:toX:y:elapsed:from:",
+#                 time_in_sec,
+#                 ["readVariable", position_x_var_name],
+#                 ["readVariable", position_y_var_name]
+#             ]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # same as in the 'distanceTo'-block workaround, the mouse-sprite is created during
+#         # conversion and not in the pre-processing -> no mouse-sprite yet
+#         assert len(second_object.scripts) == 0
+#
+#         # global variables; for the mouse-pointer workaround, the variables are created during conversion
+#         # and not in the pre-process
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 0
+#
+#         # check the flag -> indicates that mouse-sprite has to be created during conversion
+#         assert raw_project._has_mouse_position_script
+#
+#     def test_glide_to_random_single_nested(self):
+#         cls = self.__class__
+#         spinner_selection = "_random_"
+#         time_in_sec = "1"
+#         script_data = [0, 0, [["whenGreenFlag"], ["doForever", ["glideTo:", time_in_sec, spinner_selection]]]]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+#
+#         # random position also needs a workaround -> different resolutions in scratch and pocket code
+#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+#
+#         expected_first_object_script_data = \
+#             [0, 0, [["whenGreenFlag"],
+#                 ["doForever",
+#                     ["glideSecs:toX:y:elapsed:from:",
+#                         time_in_sec,
+#                         ["randomFrom:to:", left_x, right_x],
+#                         ["randomFrom:to:", lower_y, upper_y]
+#                     ]
+#                 ]
+#             ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 0
+#
+#     def test_glide_to_objects_double_nested(self):
+#         cls = self.__class__
+#         spinner_selection_random = "_random_"
+#         spinner_selection_mouse = "_mouse_"
+#         time_in_sec = "1"
+#
+#         script_data = [0, 0, [["whenGreenFlag"],
+#                                 ["doForever",
+#                                     ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
+#                                         ["glideTo:", time_in_sec, spinner_selection_random],
+#                                         ["glideTo:", time_in_sec, spinner_selection_mouse]
+#                                     ]
+#                                 ]
+#                             ]]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][0]["scripts"] = [script_data]
+#         cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE["children"][1]["scripts"] = []
+#         raw_project = scratch.RawProject(cls.GLIDE_TO_OBJECTS_DATA_TEMPLATE)
+#
+#         # variables for x and y positions of the mouse-pointer
+#         position_x_var_name = scratch.S2CC_POSITION_X_VARIABLE_NAME_PREFIX + spinner_selection_mouse
+#         position_y_var_name = scratch.S2CC_POSITION_Y_VARIABLE_NAME_PREFIX + spinner_selection_mouse
+#
+#         # random position option also needs a workaround -> different resolutions in scratch and pocket code
+#         left_x, right_x = -scratch.STAGE_WIDTH_IN_PIXELS / 2, scratch.STAGE_WIDTH_IN_PIXELS / 2
+#         lower_y, upper_y = -scratch.STAGE_HEIGHT_IN_PIXELS / 2, scratch.STAGE_HEIGHT_IN_PIXELS / 2
+#
+#         expected_first_object_script_data = \
+#             [0, 0, [["whenGreenFlag"],
+#                     ["doForever",
+#                         ["doIfElse", [">", ["randomFrom:to:", 1.0, 100.0], "50"],
+#                             ["glideSecs:toX:y:elapsed:from:",
+#                                 time_in_sec,
+#                                 ["randomFrom:to:", left_x, right_x],
+#                                 ["randomFrom:to:", lower_y, upper_y]
+#                             ],
+#                             ["glideSecs:toX:y:elapsed:from:",
+#                                 time_in_sec,
+#                                 ["readVariable", position_x_var_name],
+#                                 ["readVariable", position_y_var_name]
+#                             ]
+#                         ]
+#                     ]
+#             ]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # background object
+#         assert len(background_object.scripts) == 0
+#
+#         # first object
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_script_data)
+#         assert script == expected_script
+#
+#         # second object
+#         assert len(second_object.scripts) == 0
+#
+#
+# class TestShowSensorBlockWorkarounds(unittest.TestCase):
+#     SENSOR_HELPER_OBJECTS_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [{ "objName": "Sprite1", "scripts": [] }],
+#         "info": {}
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["scripts"] = []
+#         self.original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"][:]
+#
+#     def tearDown(self):
+#         unittest.TestCase.tearDown(self)
+#         cls = self.__class__
+#         cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = self.original_child_objects[:]
+#
+#     def test_convert_show_sensor_without_parameter_block(self):
+#         cls = self.__class__
+#         sprite_name = "Sprite1"
+#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+#         for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+#                 "target": sprite_name,
+#                 "cmd": command_name,
+#                 "param": None,
+#                 "visible": True
+#             }]
+#
+#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
+#             expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [command_name]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 0
+#             assert len(first_object.scripts) == 1
+#             script = first_object.scripts[0]
+#             expected_script = scratch.Script(expected_first_object_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(background_object._dict_object["variables"]) == 0
+#             first_object_variables = first_object._dict_object["variables"]
+#             assert len(first_object_variables) == 1
+#             assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_show_sensor_with_parameter_block(self):
+#         cls = self.__class__
+#         sprite_name = "Sprite1"
+#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+#         for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+#                 "target": sprite_name,
+#                 "cmd": command_name,
+#                 "param": param,
+#                 "visible": True
+#             }]
+#
+#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
+#             expected_first_object_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [command_name, param]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 0
+#             assert len(first_object.scripts) == 1
+#             script = first_object.scripts[0]
+#             expected_script = scratch.Script(expected_first_object_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(background_object._dict_object["variables"]) == 0
+#             first_object_variables = first_object._dict_object["variables"]
+#             assert len(first_object_variables) == 1
+#             assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_stage_specific_show_sensor_without_parameter_block(self):
+#         cls = self.__class__
+#         sprite_name = "Stage"
+#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+#         for command_name in ["xpos", "ypos", "heading", "costumeIndex", "scale"]:
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+#                 "target": sprite_name,
+#                 "cmd": command_name,
+#                 "param": None,
+#                 "visible": True
+#             }]
+#
+#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}".format(sprite_name, command_name)
+#             expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [command_name]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(first_object.scripts) == 0
+#             assert len(background_object.scripts) == 1
+#             script = background_object.scripts[0]
+#             expected_script = scratch.Script(expected_stage_object_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(first_object._dict_object["variables"]) == 0
+#             stage_object_variables = background_object._dict_object["variables"]
+#             assert len(stage_object_variables) == 1
+#             assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_stage_specific_show_sensor_with_parameter_block(self):
+#         cls = self.__class__
+#         sprite_name = "Stage"
+#         original_child_objects = cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"]
+#         for command_name, param in [("timeAndDate", "minute"), ("timeAndDate", "second")]:
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] = original_child_objects[:]
+#             cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE["children"] += [{
+#                 "target": sprite_name,
+#                 "cmd": command_name,
+#                 "param": param,
+#                 "visible": True
+#             }]
+#
+#             raw_project = scratch.RawProject(cls.SENSOR_HELPER_OBJECTS_DATA_TEMPLATE)
+#             variable_name = scratch.S2CC_SENSOR_PREFIX + "{}_{}{}".format(sprite_name, command_name, "_" + param if param else "")
+#             expected_stage_object_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [command_name, param]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(first_object.scripts) == 0
+#             assert len(background_object.scripts) == 1
+#             script = background_object.scripts[0]
+#             expected_script = scratch.Script(expected_stage_object_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(first_object._dict_object["variables"]) == 0
+#             stage_object_variables = background_object._dict_object["variables"]
+#             assert len(stage_object_variables) == 1
+#             assert stage_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#
+# class TestGetAttributeBlockWorkarounds(unittest.TestCase):
+#
+#     ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP = {
+#         "x position": "xpos",
+#         "y position": "ypos",
+#         "direction": "heading",
+#         "costume #": "costumeIndex",
+#         "costume name": "costumeName",
+#         "size": "scale",
+#         "volume": "volume"
+#     }
+#
+#     def setUp(self):
+#         unittest.TestCase.setUp(self)
+#         cls = self.__class__
+#         self.root_info = {
+#             "objName": "Stage",
+#             "sounds": [],
+#             "costumes": [],
+#             "currentCostumeIndex": 0,
+#             "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#             "penLayerID": 0,
+#             "tempoBPM": 60,
+#             "videoAlpha": 0.5,
+#             "children": [{ "objName": "Sprite1", "scripts": [] }],
+#             "scripts": [],
+#             "variables": [{ "name": "result", "value": 1, "isPersistent": False }],
+#             "info": {}
+#         }
+#
+#     def test_convert_global_variable_attribute_block(self):
+#         cls = self.__class__
+#         variable_name = "result"
+#         first_script_data = [0, 0, [["whenGreenFlag"],
+#             ["wait:elapsed:from:", 2],
+#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, "_stage_"]]
+#         ]]
+#         self.root_info["children"][0]["scripts"] = [first_script_data]
+#         raw_project = scratch.RawProject(self.root_info)
+#         first_script_data[2][2][2] = ["readVariable", variable_name]
+#         expected_first_object_first_script_data = first_script_data
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # scripts of sprite objects
+#         assert len(background_object.scripts) == 0
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_first_script_data)
+#         assert script == expected_script
+#
+#         # sprite variables
+#         global_variables = background_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert len(first_object._dict_object["variables"]) == 0
+#         assert global_variables[0] == { "name": variable_name, "value": 1, "isPersistent": False }
+#
+#     def test_convert_local_variable_of_same_object_attribute_block(self):
+#         cls = self.__class__
+#         sprite_name = "Sprite1"
+#         variable_name = "localVariable"
+#         first_script_data = [0, 0, [["whenGreenFlag"],
+#             ["wait:elapsed:from:", 2],
+#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name]]
+#         ]]
+#         self.root_info["children"][0]["scripts"] = [first_script_data]
+#         self.root_info["children"][0]["variables"] = [{ "name": variable_name, "value": 0, "isPersistent": False }]
+#         raw_project = scratch.RawProject(self.root_info)
+#         first_script_data[2][2][2] = ["readVariable", variable_name]
+#         expected_first_object_first_script_data = first_script_data
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # scripts of sprite objects
+#         assert len(background_object.scripts) == 0
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_first_script_data)
+#         assert script == expected_script
+#
+#         # sprite variables
+#         global_variables = background_object._dict_object["variables"]
+#         first_object_variables = first_object._dict_object["variables"]
+#         assert len(global_variables) == 1
+#         assert len(first_object_variables) == 1
+#         assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+#         assert first_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_local_variable_of_other_object_attribute_block(self):
+#         cls = self.__class__
+#         sprite_name_of_other_object = "Sprite2"
+#         variable_name = "localVariableOfSprite2"
+#         self.root_info["children"] += [{
+#             "objName": sprite_name_of_other_object,
+#             "scripts": [],
+#             "variables": [{ "name": variable_name, "value": 0, "isPersistent": False }]
+#         }]
+#         first_script_data = [0, 0, [["whenGreenFlag"],
+#             ["wait:elapsed:from:", 2],
+#             ["setVar:to:", "result", ["getAttribute:of:", variable_name, sprite_name_of_other_object]]
+#         ]]
+#         self.root_info["children"][0]["scripts"] = [first_script_data]
+#         raw_project = scratch.RawProject(self.root_info)
+#         helper_variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_readVariable:{}".format(sprite_name_of_other_object, variable_name)
+#         first_script_data[2][2][2] = ["readVariable", helper_variable_name]
+#         expected_first_object_first_script_data = first_script_data
+#         expected_second_object_first_script_data = [0, 0, [["whenGreenFlag"], ["doForever", [
+#             ["setVar:to:", helper_variable_name, ["readVariable", variable_name]],
+#             ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#         ]]]]
+#
+#         # validate
+#         assert len(raw_project.objects) == 3
+#         [background_object, first_object, second_object] = raw_project.objects
+#
+#         # scripts of sprite objects
+#         assert len(background_object.scripts) == 0
+#         assert len(first_object.scripts) == 1
+#         assert len(second_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_first_script_data)
+#         assert script == expected_script
+#         script = second_object.scripts[0]
+#         expected_script = scratch.Script(expected_second_object_first_script_data)
+#         assert script == expected_script
+#
+#         # sprite variables
+#         global_variables = background_object._dict_object["variables"]
+#         second_object_variables = second_object._dict_object["variables"]
+#         assert len(global_variables) == 2
+#         assert len(first_object._dict_object["variables"]) == 0
+#         assert len(second_object_variables) == 1
+#         assert global_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+#         assert global_variables[1] == { "name": helper_variable_name, "value": 0, "isPersistent": False }
+#         assert second_object_variables[0] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_background_specific_attributes_of_same_object_block(self):
+#         cls = self.__class__
+#         stage_name = "Stage"
+#         for attribute_name, sensor_name in [("backdrop #", "backgroundIndex"), ("backdrop name", "sceneName")]:
+#             first_script_data = [0, 0, [["whenGreenFlag"],
+#                 ["wait:elapsed:from:", 2],
+#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, stage_name]]
+#             ]]
+#             self.root_info["scripts"] = [first_script_data]
+#             raw_project = scratch.RawProject(self.root_info)
+#             first_script_data[2][2][2] = [sensor_name]
+#             expected_stage_object_first_script_data = first_script_data
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 1
+#             assert len(first_object.scripts) == 0
+#             script = background_object.scripts[0]
+#             expected_script = scratch.Script(expected_stage_object_first_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(background_object._dict_object["variables"]) == 1
+#             assert len(first_object._dict_object["variables"]) == 0
+#
+#     def test_convert_attribute_of_same_object_block(self):
+#         cls = self.__class__
+#         sprite_name = "Sprite1"
+#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+#             first_script_data = [0, 0, [["whenGreenFlag"],
+#                 ["wait:elapsed:from:", 2],
+#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, sprite_name]]
+#             ]]
+#             self.root_info["children"][0]["scripts"] = [first_script_data]
+#             raw_project = scratch.RawProject(self.root_info)
+#             first_script_data[2][2][2] = [sensor_name]
+#             expected_first_object_first_script_data = first_script_data
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 0
+#             assert len(first_object.scripts) == 1
+#             script = first_object.scripts[0]
+#             expected_script = scratch.Script(expected_first_object_first_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             assert len(background_object._dict_object["variables"]) == 1
+#             assert len(first_object._dict_object["variables"]) == 0
+#
+#     def test_should_convert_attribute_with_formula_block_to_zero_placeholder(self):
+#         cls = self.__class__
+#         first_script_data = [0, 0, [["whenGreenFlag"],
+#             ["wait:elapsed:from:", 2],
+#             ["setVar:to:", "result", ["getAttribute:of:", "x position", ["+", 1, 2]]]
+#         ]]
+#         self.root_info["children"][0]["scripts"] = [first_script_data]
+#         raw_project = scratch.RawProject(self.root_info)
+#         first_script_data[2][2][2] = 0
+#         expected_first_object_first_script_data = first_script_data
+#
+#         # validate
+#         assert len(raw_project.objects) == 2
+#         [background_object, first_object] = raw_project.objects
+#
+#         # scripts of sprite objects
+#         assert len(background_object.scripts) == 0
+#         assert len(first_object.scripts) == 1
+#         script = first_object.scripts[0]
+#         expected_script = scratch.Script(expected_first_object_first_script_data)
+#         assert script == expected_script
+#
+#         # sprite variables
+#         assert len(background_object._dict_object["variables"]) == 1
+#         assert len(first_object._dict_object["variables"]) == 0
+#
+#     def test_convert_attribute_of_other_object_block(self):
+#         cls = self.__class__
+#         other_object_name = "Stage"
+#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+#             first_script_data = [0, 0, [["whenGreenFlag"],
+#                 ["wait:elapsed:from:", 2],
+#                 ["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]
+#             ]]
+#             self.root_info["children"][0]["scripts"] = [first_script_data]
+#             raw_project = scratch.RawProject(self.root_info)
+#             variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
+#             expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [sensor_name]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#             first_script_data[2][2][2] = ["readVariable", variable_name]
+#             expected_first_object_first_script_data = first_script_data
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 1
+#             assert len(first_object.scripts) == 1
+#             script = background_object.scripts[0]
+#             expected_script = scratch.Script(expected_background_object_first_script_data)
+#             assert script == expected_script
+#             script = first_object.scripts[0]
+#             expected_script = scratch.Script(expected_first_object_first_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             stage_object_variables = background_object._dict_object["variables"]
+#             assert len(stage_object_variables) == 2
+#             assert len(first_object._dict_object["variables"]) == 0
+#             assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+#             assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#     def test_convert_attribute_of_other_object_block_encapsulated(self):
+#         cls = self.__class__
+#         other_object_name = "Stage"
+#         for attribute_name, sensor_name in cls.ATTRIBUTE_NAME_TO_SENSOR_NAME_MAP.iteritems():
+#             first_script_data = [0, 0, [["whenGreenFlag"],
+#                 ["wait:elapsed:from:", 2],
+#                 ["doRepeat", 10,
+#                     [["doIf", False, [["doIfElse", False,
+#                         [["doForever",
+#                             [["setVar:to:", "result", ["getAttribute:of:", attribute_name, "_stage_"]]]
+#                         ]], 0]]]
+#                 ]]
+#             ]]
+#             self.root_info["children"][0]["scripts"] = [first_script_data]
+#             raw_project = scratch.RawProject(self.root_info)
+#             variable_name = scratch.S2CC_GETATTRIBUTE_PREFIX + "{}_{}".format(other_object_name, sensor_name)
+#             expected_background_object_first_script_data = [0, 0, [['whenGreenFlag'],
+#                 ['doForever', [
+#                     ["setVar:to:", variable_name, [sensor_name]],
+#                     ["wait:elapsed:from:", scratch.UPDATE_HELPER_VARIABLE_TIMEOUT]
+#                 ]]
+#             ]]
+#             first_script_data[2][2][2][0][2][0][2][0][1][0][2] = ["readVariable", variable_name]
+#             expected_first_object_first_script_data = first_script_data
+#
+#             # validate
+#             assert len(raw_project.objects) == 2
+#             [background_object, first_object] = raw_project.objects
+#
+#             # scripts of sprite objects
+#             assert len(background_object.scripts) == 1
+#             assert len(first_object.scripts) == 1
+#             script = background_object.scripts[0]
+#             expected_script = scratch.Script(expected_background_object_first_script_data)
+#             assert script == expected_script
+#             script = first_object.scripts[0]
+#             expected_script = scratch.Script(expected_first_object_first_script_data)
+#             assert script == expected_script
+#
+#             # sprite variables
+#             stage_object_variables = background_object._dict_object["variables"]
+#             assert len(stage_object_variables) == 2
+#             assert len(first_object._dict_object["variables"]) == 0
+#             assert stage_object_variables[0] == { "name": "result", "value": 1, "isPersistent": False }
+#             assert stage_object_variables[1] == { "name": variable_name, "value": 0, "isPersistent": False }
+#
+#
+# class CommentWorkaround(unittest.TestCase):
+#     COMMENT_DATA_TEMPLATE = {
+#         "objName": "Stage",
+#         "sounds": [],
+#         "costumes": [],
+#         "currentCostumeIndex": 0,
+#         "penLayerMD5": "5c81a336fab8be57adc039a8a2b33ca9.png",
+#         "penLayerID": 0,
+#         "tempoBPM": 60,
+#         "videoAlpha": 0.5,
+#         "children": [],
+#         "info": {}
+#     }
+#
+#     def get_stage(self, scripts, comments):
+#         data = self.COMMENT_DATA_TEMPLATE
+#         data["scriptComments"] = comments
+#         data["scripts"] = scripts
+#         raw_project = scratch.RawProject(data)
+#         self.assertEqual(1, len(raw_project.objects))
+#         return raw_project.objects[0]
+#
+#     @classmethod
+#     def get_comment(cls, blockId, text):
+#         return [0, 0, 0, 0, False, blockId, text]
+#
+#     def test_simple_comment(self):
+#         for blockId in [-1, 0, 1]:
+#             script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1]]]
+#             comment = self.get_comment(1, "test_comment")
+#             stage = self.get_stage([script], [comment])
+#
+#             self.assertEqual(1, len(stage.scripts))
+#             script = stage.scripts[0]
+#             self.assertListEqual([['note:', 'test_comment'], ['wait:elapsed:from:', 1]], script.blocks)
+#
+#     def test_condition_comment(self):
+#         script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", 1], ["wait:elapsed:from:", ["+", 1, 2]], ["wait:elapsed:from:", 1]]]
+#         comments = [self.get_comment(3, "condition_comment"), self.get_comment(4, "wait_comment")]
+#         stage = self.get_stage([script], comments)
+#
+#         self.assertEqual(1, len(stage.scripts))
+#         script = stage.scripts[0]
+#         expected_blocks = [['wait:elapsed:from:', 1],
+#                            ['note:', 'condition_comment'],
+#                            ['wait:elapsed:from:', ['+', 1, 2]],
+#                            ['note:', 'wait_comment'],
+#                            ['wait:elapsed:from:', 1]]
+#         self.assertListEqual(expected_blocks, script.blocks)
+#
+#     def test_comment_in_if(self):
+#         script = [0, 0, [["whenGreenFlag"], ["doIf", [">", 5, 4], [["wait:elapsed:from:", 1]]], ["wait:elapsed:from:", 1]]]
+#         comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "after_if_comment")]
+#         stage = self.get_stage([script], comments)
+#
+#         self.assertEqual(1, len(stage.scripts))
+#         script = stage.scripts[0]
+#         expected_blocks = [['doIf',
+#                             ['>', 5, 4],
+#                             [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]]],
+#                            ['note:', 'after_if_comment'],
+#                            ['wait:elapsed:from:', 1]]
+#         self.assertListEqual(expected_blocks, script.blocks)
+#
+#     def test_comment_in_else(self):
+#         script = [0, 0, [["whenGreenFlag"], ["doIfElse", [">", 5, 4], [["wait:elapsed:from:", 1]], [["wait:elapsed:from:", 2]]], ["wait:elapsed:from:", 1]]]
+#         comments = [self.get_comment(3, "in_if_comment"), self.get_comment(4, "in_else_comment"), self.get_comment(5, "after_if_comment")]
+#         stage = self.get_stage([script], comments)
+#
+#         self.assertEqual(1, len(stage.scripts))
+#         script = stage.scripts[0]
+#         expected_blocks = [['doIfElse',
+#                             ['>', 5, 4],
+#                             [['note:', 'in_if_comment'], ['wait:elapsed:from:', 1]],
+#                             [['note:', 'in_else_comment'], ['wait:elapsed:from:', 2]]],
+#                            ['note:', 'after_if_comment'],
+#                            ['wait:elapsed:from:', 1]]
+#         self.assertListEqual(expected_blocks, script.blocks)
+#
+#     def test_multiple_comments_same_brick(self):
+#         NUM_COMMENTS = 20
+#         for blockId in [-1, 0, 1, 2]:
+#             script = [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
+#             comments = [self.get_comment(1, "test_comment_{}".format(i)) for i in range(NUM_COMMENTS)]
+#             stage = self.get_stage([script], comments)
+#
+#             self.assertEqual(1, len(stage.scripts))
+#             script = stage.scripts[0]
+#             expected_blocks = [["note:", "test_comment_{}".format(i)] for i in range(NUM_COMMENTS)][::-1] + [["wait:elapsed:from:", ["+", 1, 2]]]
+#             self.assertListEqual(expected_blocks, script.blocks)
+#
+#     def test_invalid_blocks(self):
+#         scripts = [
+#             [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]],
+#             [0, 0, [["+", 4, 3]]],
+#             [0, 0, [["wait:elapsed:from:", "-", 2, -1]]],
+#             [0, 0, [["whenGreenFlag"], ["wait:elapsed:from:", ["+", 1, 2]]]]
+#         ]
+#         comments = [self.get_comment(i, "comment_{}".format(i)) for i in range(8)]
+#         stage = self.get_stage(scripts, comments)
+#
+#         self.assertEqual(2, len(stage.scripts))
+#         expected_blocks_0 = [['note:', 'comment_0'],
+#                              ['note:', 'comment_1'],
+#                              ['note:', 'comment_2'],
+#                              ['wait:elapsed:from:', ['+', 1, 2]]]
+#         self.assertListEqual(expected_blocks_0, stage.scripts[0].blocks)
+#         expected_blocks_1 = [['note:', 'comment_5'],
+#                              ['note:', 'comment_6'],
+#                              ['note:', 'comment_7'],
+#                              ['wait:elapsed:from:', ['+', 1, 2]]]
+#         self.assertListEqual(expected_blocks_1, stage.scripts[1].blocks)
+#
+#     def test_general_comment_without_scripts(self):
+#         comment = self.get_comment(-1, "general comment")
+#         stage = self.get_stage([], [comment])
+#         self.assertListEqual([], stage.scripts)
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']


### PR DESCRIPTION
Removed all hardcoding of scratch3 opcodes, used opcode classes instead.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines) (Replace occurences of CATROBAT or CAT with STCC)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Post a message in the *#stcc* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
